### PR TITLE
Fix Linux build issues. gtest compilation failure, test flag, and copying local configs to install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,12 +54,6 @@ if(WIN32)
 	endif()
 endif()
 
-# ------------
-#  Test files
-# ------------
-
-include(DownloadGoogleTest)
-
 set(eoserv_LIBRARIES)
 
 # ----------------
@@ -162,6 +156,12 @@ if(BuildType STREQUAL "debug")
 	ENDIF(CMAKE_COMPILER_IS_GNUCC)
 endif()
 
+# ------------
+#  Test files
+# ------------
+
+include(DownloadGoogleTest)
+
 # ---------
 #  Outputs
 # ---------
@@ -238,6 +238,8 @@ foreach (File ${ExtraFiles})
 
 	install(FILES ${File} DESTINATION ${Dir})
 endforeach()
+
+install(DIRECTORY ${LocalConf} DESTINATION ${LocalConf} FILES_MATCHING PATTERN "*.ini")
 
 # ---------------------
 #  Precompiled Headers

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -124,7 +124,13 @@ function main() {
   popd > /dev/null
 
   if [[ "${opt_test}" == "true" ]]; then
-      ./install/test/eoserv_test
+    local test_runner="${install_dir}"/test/eoserv_test
+    if [[ ! -f "${test_runner}" ]]; then
+      echo "Error: the test runner \"${test_runner}\" does not exist."
+      echo "Notice: you must build and install to run tests."
+      return 1
+    fi
+    "${test_runner}"
   fi
 
   return 0
@@ -139,6 +145,7 @@ function display_usage() {
   echo "  -c --clean                  Clean before building."
   echo "  -b <dir> --build_dir <dir>  Build directory [default: build]."
   echo "  -n --no-install             Build without local install."
+  echo "  -t --test                   Execute tests."
   echo "  --mariadb (ON|OFF)          MariaDB/MySQL support [default: OFF]."
   echo "  --sqlite (ON|OFF)           SQLite support [default: OFF]."
   echo "  --sqlserver (ON|OFF)        SQL Server support [default: ON]."

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -8,7 +8,7 @@ function main() {
   local build_dir="${PWD}/build"
   local build_mode="Release"
   local install_dir="${PWD}/install"
-  local target="eoserv"
+  local target="install"
   local opt_clean="false"
   local opt_help="false"
   local opt_test="false"
@@ -31,8 +31,8 @@ function main() {
         build_dir="$2"
         shift
         ;;
-      -i|--install)
-        target="install"
+      -n|--no-install)
+        target="eoserv"
         ;;
       -t|--test)
         opt_test="true"
@@ -53,7 +53,6 @@ function main() {
         sqlserver="$2"
         shift
         ;;
-
       *)
         echo "Error: unsupported option \"${option}\""
         return 1
@@ -139,7 +138,7 @@ function display_usage() {
   echo "  -d --debug                  Build with debug symbols."
   echo "  -c --clean                  Clean before building."
   echo "  -b <dir> --build_dir <dir>  Build directory [default: build]."
-  echo "  -i --install                Install build in install directory."
+  echo "  -n --no-install             Build without local install."
   echo "  --mariadb (ON|OFF)          MariaDB/MySQL support [default: OFF]."
   echo "  --sqlite (ON|OFF)           SQLite support [default: OFF]."
   echo "  --sqlserver (ON|OFF)        SQL Server support [default: ON]."

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -125,7 +125,7 @@ function main() {
   popd > /dev/null
 
   if [[ "${opt_test}" == "true" ]]; then
-      echo "./install/test/eoserv_test"
+      ./install/test/eoserv_test
   fi
 
   return 0

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -260,3 +260,7 @@ set(ExtraFiles
 set(TestFiles
 	src/test/config_test.cpp
 )
+
+set(LocalConf
+	config_local/
+)


### PR DESCRIPTION
- google test failed to compile since the CXX standard was set after the google test project was included
- test flag on linux was only printing the name of the test exe instead of running tests
- added copy for local configs (config_local directory) on install target