### PR TITLE
Remove static keyword from SLN request thread to prevent errors when re-queueing SLN requests

### DIFF
--- a/src/sln.cpp
+++ b/src/sln.cpp
@@ -102,15 +102,15 @@ void SLN::Request()
 
 	try
 	{
-		static std::thread thread(SLN::RequestThread, request);
+		std::thread thread(SLN::RequestThread, request);
 		if (!thread.native_handle())
 			throw std::runtime_error("Failed to create SLN request thread");
 
 		thread.detach();
 	}
-	catch (...)
+	catch (std::exception &e)
 	{
-		throw std::runtime_error("Failed to create SLN request thread");
+		throw std::runtime_error(e.what());
 	}
 }
 


### PR DESCRIPTION
SLN is designed to repeatedly kick off request threads on a timer. Only the first request is created when it is declared static. Removing static keyword so subsequent requests get created properly and SLN works as expected.