### PR TITLE
Support versioned passwords

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -9,7 +9,8 @@
         {
             "name": "SqlServer - Windows",
             "includePath": [
-                "build/googletest-src/googletest/include"
+                "build/googletest-src/googletest/include",
+                "build/bcrypt-src/include"
             ],
             "defines": [
                 "DATABASE_SQLSERVER"
@@ -29,7 +30,8 @@
         {
             "name": "MySQL + SqlServer - Windows",
             "includePath": [
-                "build/googletest-src/googletest/include"
+                "build/googletest-src/googletest/include",
+                "build/bcrypt-src/include"
             ],
             "defines": [
                 "DATABASE_SQLSERVER",
@@ -50,7 +52,8 @@
         {
             "name": "SqlServer - Linux",
             "includePath": [
-                "build/googletest-src/googletest/include"
+                "build/googletest-src/googletest/include",
+                "build/bcrypt-src/include"
             ],
             "defines": [
                 "DATABASE_SQLSERVER"
@@ -70,7 +73,8 @@
         {
             "name": "MySQL + SqlServer - Linux",
             "includePath": [
-                "build/googletest-src/googletest/include"
+                "build/googletest-src/googletest/include",
+                "build/bcrypt-src/include"
             ],
             "defines": [
                 "DATABASE_SQLSERVER",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,11 @@ add_executable(eoserv_test
 	${TestFiles}
 )
 target_link_libraries(eoserv_test gtest_main)
-add_dependencies(eoserv_test eoserv-pch)
+
+if(EOSERV_USE_PRECOMPILED_HEADERS)
+	add_dependencies(eoserv_test eoserv-pch)
+endif()
+
 add_test(NAME eoserv_test COMMAND eoserv_test)
 
 set (CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/install)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,11 @@ else()
 	list(APPEND eoserv_LIBRARIES pthread)
 endif()
 
+include(DownloadBcrypt)
+
+target_include_directories(eoserv PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
+list(APPEND eoserv_LIBRARIES bcrypt)
+
 target_link_libraries(eoserv ${eoserv_LIBRARIES})
 
 install(TARGETS eoserv RUNTIME DESTINATION .)

--- a/cmake/DownloadBcrypt.cmake
+++ b/cmake/DownloadBcrypt.cmake
@@ -1,0 +1,23 @@
+
+# Download and unpack bcrypt at configure time
+configure_file(${CMAKE_SOURCE_DIR}/cmake/bcryptproj.cmake bcrypt-download/CMakeLists.txt)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bcrypt-download )
+if(result)
+  message(FATAL_ERROR "CMake step for bcrypt failed: ${result}")
+endif()
+
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bcrypt-download )
+if(result)
+  message(FATAL_ERROR "Build step for bcrypt failed: ${result}")
+endif()
+
+# Add bcrypt directly to our build. This defines
+# the gtest and bcrypt targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/bcrypt-src
+                 ${CMAKE_CURRENT_BINARY_DIR}/bcrypt-build
+                 EXCLUDE_FROM_ALL)

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -167,6 +167,8 @@ set(eoserv_ALL_SOURCE_FILES
 	src/util/rpn.cpp
 	src/util/rpn.hpp
 	src/util/secure_string.hpp
+	src/util/semaphore.cpp
+	src/util/semaphore.hpp
 	src/util/variant.cpp
 	src/util/variant.hpp
 	src/version.h

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -131,6 +131,8 @@ set(eoserv_ALL_SOURCE_FILES
 	src/handlers/Welcome.cpp
 	src/hash.cpp
 	src/hash.hpp
+	src/hashupdater.cpp
+	src/hashupdater.hpp
 	src/i18n.cpp
 	src/i18n.hpp
 	src/main.cpp
@@ -248,6 +250,8 @@ set(ExtraFiles
 	install_sqlserver.sql
 	upgrade/0.5.2_to_0.5.3.sql
 	upgrade/0.6.2_to_0.7.0.sql
+	upgrade/0.7.0_to_0.7.1.sql
+	upgrade/0.7.0_to_0.7.1_sqlserver.sql
 
 	${ConfigFiles}
 	${LangFiles}

--- a/cmake/bcryptproj.cmake
+++ b/cmake/bcryptproj.cmake
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.2)
+cmake_policy(SET CMP0054 NEW)
+
+project(bcrypt-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(bcrypt
+  GIT_REPOSITORY    https://github.com/trusch/libbcrypt.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/bcrypt-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/bcrypt-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/config/server.ini
+++ b/config/server.ini
@@ -56,6 +56,12 @@ PasswordSalt = ChangeMe
 # This should not be changed unless you are adding a new hashing function for passwords.
 PasswordCurrentVersion = 2
 
+## BcryptWorkload (int)
+# Allows tuning the complexity of bcrypt. Higher values require more computing power.
+# Defaults to 12 if <4 or >31. Using a value <10 is irresponsible.
+# Changing this value requires restart of eoserv
+BcryptWorkload = 12
+
 ## SeoseCompat (string)
 # Compatability with Seose2EOSERV converted databases
 # WARNING: Changing this will break any existing users' passwords.

--- a/config/server.ini
+++ b/config/server.ini
@@ -49,6 +49,13 @@ MaxLoginAttempts = 3
 # WARNING: Changing this will break any existing users' passwords.
 PasswordSalt = ChangeMe
 
+## PasswordCurrentVersion (string)
+# Current version of the password hashing function to use.
+# 1 == sha256 (deprecated)
+# 2 == bcrypt
+# This should not be changed unless you are adding a new hashing function for passwords.
+PasswordCurrentVersion = 2
+
 ## SeoseCompat (string)
 # Compatability with Seose2EOSERV converted databases
 # WARNING: Changing this will break any existing users' passwords.

--- a/config/server.ini
+++ b/config/server.ini
@@ -49,7 +49,7 @@ MaxLoginAttempts = 3
 # WARNING: Changing this will break any existing users' passwords.
 PasswordSalt = ChangeMe
 
-## PasswordCurrentVersion (string)
+## PasswordCurrentVersion (int)
 # Current version of the password hashing function to use.
 # 1 == sha256 (deprecated)
 # 2 == bcrypt

--- a/install.sql
+++ b/install.sql
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS `accounts`
 (
 	`username`         VARCHAR(16) NOT NULL,
-	`password`         CHAR(64)    NOT NULL,
+	`password`         VARCHAR(64) NOT NULL,
 	`fullname`         VARCHAR(64) NOT NULL,
 	`location`         VARCHAR(64) NOT NULL,
 	`email`            VARCHAR(64) NOT NULL,

--- a/install.sql
+++ b/install.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS `accounts`
 	`lastip`           VARCHAR(15)          DEFAULT NULL,
 	`created`          INTEGER     NOT NULL,
 	`lastused`         INTEGER              DEFAULT NULL,
-	`password_version` INTEGER     NOT NULL DEFAULT 1,
+	`password_version` INTEGER     NOT NULL DEFAULT 2,
 
 	PRIMARY KEY (`username`)
 );

--- a/install.sql
+++ b/install.sql
@@ -1,17 +1,18 @@
 
 CREATE TABLE IF NOT EXISTS `accounts`
 (
-	`username`   VARCHAR(16) NOT NULL,
-	`password`   CHAR(64)    NOT NULL,
-	`fullname`   VARCHAR(64) NOT NULL,
-	`location`   VARCHAR(64) NOT NULL,
-	`email`      VARCHAR(64) NOT NULL,
-	`computer`   VARCHAR(64) NOT NULL,
-	`hdid`       INTEGER     NOT NULL,
-	`regip`      VARCHAR(15) NOT NULL,
-	`lastip`     VARCHAR(15)          DEFAULT NULL,
-	`created`    INTEGER     NOT NULL,
-	`lastused`   INTEGER              DEFAULT NULL,
+	`username`         VARCHAR(16) NOT NULL,
+	`password`         CHAR(64)    NOT NULL,
+	`fullname`         VARCHAR(64) NOT NULL,
+	`location`         VARCHAR(64) NOT NULL,
+	`email`            VARCHAR(64) NOT NULL,
+	`computer`         VARCHAR(64) NOT NULL,
+	`hdid`             INTEGER     NOT NULL,
+	`regip`            VARCHAR(15) NOT NULL,
+	`lastip`           VARCHAR(15)          DEFAULT NULL,
+	`created`          INTEGER     NOT NULL,
+	`lastused`         INTEGER              DEFAULT NULL,
+	`password_version` INTEGER     NOT NULL DEFAULT 1,
 
 	PRIMARY KEY (`username`)
 );

--- a/install_sqlserver.sql
+++ b/install_sqlserver.sql
@@ -3,7 +3,7 @@ BEGIN
     CREATE TABLE [accounts]
     (
         [username]         VARCHAR(16) NOT NULL,
-        [password]         CHAR(64)    NOT NULL,
+        [password]         VARCHAR(64) NOT NULL,
         [fullname]         VARCHAR(64) NOT NULL,
         [location]         VARCHAR(64) NOT NULL,
         [email]            VARCHAR(64) NOT NULL,

--- a/install_sqlserver.sql
+++ b/install_sqlserver.sql
@@ -2,17 +2,18 @@ IF OBJECT_ID(N'accounts', 'U') is null
 BEGIN
     CREATE TABLE [accounts]
     (
-        [username]   VARCHAR(16) NOT NULL,
-        [password]   CHAR(64)    NOT NULL,
-        [fullname]   VARCHAR(64) NOT NULL,
-        [location]   VARCHAR(64) NOT NULL,
-        [email]      VARCHAR(64) NOT NULL,
-        [computer]   VARCHAR(64) NOT NULL,
-        [hdid]       INTEGER     NOT NULL,
-        [regip]      VARCHAR(15) NOT NULL,
-        [lastip]     VARCHAR(15)          DEFAULT NULL,
-        [created]    INTEGER     NOT NULL,
-        [lastused]   INTEGER              DEFAULT NULL,
+        [username]         VARCHAR(16) NOT NULL,
+        [password]         CHAR(64)    NOT NULL,
+        [fullname]         VARCHAR(64) NOT NULL,
+        [location]         VARCHAR(64) NOT NULL,
+        [email]            VARCHAR(64) NOT NULL,
+        [computer]         VARCHAR(64) NOT NULL,
+        [hdid]             INTEGER     NOT NULL,
+        [regip]            VARCHAR(15) NOT NULL,
+        [lastip]           VARCHAR(15)          DEFAULT NULL,
+        [created]          INTEGER     NOT NULL,
+        [lastused]         INTEGER              DEFAULT NULL,
+        [password_version] INTEGER     NOT NULL DEFAULT 1,
 
         PRIMARY KEY ([username])
     )

--- a/install_sqlserver.sql
+++ b/install_sqlserver.sql
@@ -13,7 +13,7 @@ BEGIN
         [lastip]           VARCHAR(15)          DEFAULT NULL,
         [created]          INTEGER     NOT NULL,
         [lastused]         INTEGER              DEFAULT NULL,
-        [password_version] INTEGER     NOT NULL DEFAULT 1,
+        [password_version] INTEGER     NOT NULL DEFAULT 2,
 
         PRIMARY KEY ([username])
     )

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -944,9 +944,8 @@ void Database::ExecuteFile(const std::string& filename)
 	queries.push_back(query);
 	query.erase();
 
-	std::remove_if(UTIL_RANGE(queries), [&](const std::string& s) { return util::trim(s).length() == 0; });
-
-	this->ExecuteQueries(UTIL_RANGE(queries));
+	auto queriesEnd = std::remove_if(UTIL_RANGE(queries), [&](const std::string& s) { return util::trim(s).length() == 0; });
+	this->ExecuteQueries(queries.begin(), queriesEnd);
 }
 
 bool Database::Pending() const

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -184,6 +184,7 @@ Database::Database()
 { }
 
 Database::Database(Database::Engine type, const std::string& host, unsigned short port, const std::string& user, const std::string& pass, const std::string& db, bool connectnow)
+	: impl(new impl_)
 {
 	this->connected = false;
 
@@ -359,6 +360,16 @@ void Database::Connect(Database::Engine type, const std::string& host, unsigned 
 					HandleSqlServerError(SQL_HANDLE_STMT, this->impl->hstmt, ret, Console::Err);
 				this->connected = false;
 				throw Database_OpenFailed("Unable to allocate ODBC statement handle");
+			}
+
+			// Set transaction isolation level so that reads from other connections aren't blocked
+			// EOSERV operates in a pattern where transactions are always open (committed periodically)
+			// Default isolation level in SQL Server is `READ COMMITTED`
+			//
+			Database_Result res = this->Query("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED");
+			if (res.error)
+			{
+				throw Database_OpenFailed("Unable to set transaction isolation level for SQL Server!");
 			}
 
 			break;
@@ -789,7 +800,7 @@ Database::QueryParameterPair Database::ParseQueryArgs(const char * format, va_li
 		}
 	}
 
-	return std::move(QueryParameterPair(finalquery, parameters));
+	return QueryParameterPair(finalquery, parameters);
 }
 
 Database_Result Database::Query(const char *format, ...)
@@ -801,7 +812,7 @@ Database_Result Database::Query(const char *format, ...)
 
 	std::va_list ap;
 	va_start(ap, format);
-	QueryParameterPair queryState = this->ParseQueryArgs(format, ap);
+	QueryParameterPair queryState = std::move(this->ParseQueryArgs(format, ap));
 	va_end(ap);
 
 	std::string& finalquery = queryState.first;

--- a/src/eoserv_config.cpp
+++ b/src/eoserv_config.cpp
@@ -50,6 +50,7 @@ void eoserv_config_validate_config(Config& config)
 	eoserv_config_default(config, "EnforceSessions"    , true);
 	eoserv_config_default(config, "PasswordSalt"       , "ChangeMe");
 	eoserv_config_default(config, "PasswordCurrentVersion", 2);
+	eoserv_config_default(config, "BcryptWorkload"     , 12);
 	eoserv_config_default(config, "SeoseCompat"        , "ChangeMe");
 	eoserv_config_default(config, "SeoseCompatKey"     , "D4q9_f30da%#q02#)8");
 	eoserv_config_default(config, "DBType"             , "mysql");

--- a/src/eoserv_config.cpp
+++ b/src/eoserv_config.cpp
@@ -49,6 +49,7 @@ void eoserv_config_validate_config(Config& config)
 	eoserv_config_default(config, "EnforceTimestamps"  , true);
 	eoserv_config_default(config, "EnforceSessions"    , true);
 	eoserv_config_default(config, "PasswordSalt"       , "ChangeMe");
+	eoserv_config_default(config, "PasswordCurrentVersion", 2);
 	eoserv_config_default(config, "SeoseCompat"        , "ChangeMe");
 	eoserv_config_default(config, "SeoseCompatKey"     , "D4q9_f30da%#q02#)8");
 	eoserv_config_default(config, "DBType"             , "mysql");

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -11,14 +11,16 @@
 
 #include <string>
 
-std::string sha256(const std::string& str)
+std::string sha256(const std::string& str, const std::string& salt)
 {
 	sha256_context ctx;
 	char digest[32];
 	char cdigest[64];
 
+	std::string toHash = salt + str;
+
 	sha256_start(&ctx);
-	sha256_update(&ctx, str.c_str(), str.length());
+	sha256_update(&ctx, toHash.c_str(), toHash.length());
 	sha256_finish(&ctx, digest);
 
 	for (int i = 0; i < 32; ++i)
@@ -30,7 +32,21 @@ std::string sha256(const std::string& str)
 	return std::string(cdigest, 64);
 }
 
-std::string bcrypt(const std::string& str)
+int bcrypt_generatesalt(char * salt, int workfactor)
 {
-	return BCrypt::generateHash(str);
+	return bcrypt_gensalt(workfactor, salt);
+}
+
+std::string bcrypt(const std::string& str, const std::string& salt)
+{
+	static int workFactor = 12;
+
+	char retHash[BCRYPT_HASHSIZE] = {0};
+	int hashRes = bcrypt_hashpw(str.c_str(), salt.c_str(), retHash);
+	if (hashRes != 0)
+	{
+		throw std::runtime_error("Unable to compute bcrypt hash");
+	}
+
+	return std::string(retHash, BCRYPT_HASHSIZE);
 }

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -28,3 +28,8 @@ std::string sha256(const std::string& str)
 
 	return std::string(cdigest, 64);
 }
+
+std::string bcrypt(const std::string& str)
+{
+	return "";
+}

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -7,6 +7,7 @@
 #include "hash.hpp"
 
 #include "sha256.h"
+#include "bcrypt/BCrypt.hpp"
 
 #include <string>
 
@@ -31,5 +32,5 @@ std::string sha256(const std::string& str)
 
 std::string bcrypt(const std::string& str)
 {
-	return "";
+	return BCrypt::generateHash(str);
 }

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -37,7 +37,7 @@ bool Sha256Hasher::check(const std::string& toCheck, const std::string& hashed) 
 
 std::string BcryptHasher::hash(const std::string& input) const
 {
-	return BCrypt::generateHash(input);
+	return BCrypt::generateHash(input, _workload);
 }
 
 bool BcryptHasher::check(const std::string& toCheck, const std::string& hashed) const

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -11,16 +11,14 @@
 
 #include <string>
 
-std::string sha256(const std::string& str, const std::string& salt)
+std::string Sha256Hasher::hash(const std::string& input) const
 {
 	sha256_context ctx;
 	char digest[32];
 	char cdigest[64];
 
-	std::string toHash = salt + str;
-
 	sha256_start(&ctx);
-	sha256_update(&ctx, toHash.c_str(), toHash.length());
+	sha256_update(&ctx, input.c_str(), input.length());
 	sha256_finish(&ctx, digest);
 
 	for (int i = 0; i < 32; ++i)
@@ -32,21 +30,17 @@ std::string sha256(const std::string& str, const std::string& salt)
 	return std::string(cdigest, 64);
 }
 
-int bcrypt_generatesalt(char * salt, int workfactor)
+bool Sha256Hasher::check(const std::string& toCheck, const std::string& hashed) const
 {
-	return bcrypt_gensalt(workfactor, salt);
+	return this->hash(toCheck) == hashed;
 }
 
-std::string bcrypt(const std::string& str, const std::string& salt)
+std::string BcryptHasher::hash(const std::string& input) const
 {
-	static int workFactor = 12;
+	return BCrypt::generateHash(input);
+}
 
-	char retHash[BCRYPT_HASHSIZE] = {0};
-	int hashRes = bcrypt_hashpw(str.c_str(), salt.c_str(), retHash);
-	if (hashRes != 0)
-	{
-		throw std::runtime_error("Unable to compute bcrypt hash");
-	}
-
-	return std::string(retHash, BCRYPT_HASHSIZE);
+bool BcryptHasher::check(const std::string& toCheck, const std::string& hashed) const
+{
+	return BCrypt::validatePassword(toCheck, hashed);
 }

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -11,6 +11,7 @@
 
 enum HashFunc
 {
+    NONE = 0,
     SHA256 = 1,
     BCRYPT = 2
 };

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -9,9 +9,20 @@
 
 #include <string>
 
+enum HashFunc
+{
+    SHA256 = 1,
+    BCRYPT = 2
+};
+
 /**
- * Convert a string to the hex representation of it's sha256 hash
+ * Convert a string to the hex representation of its sha256 hash
  */
 std::string sha256(const std::string&);
+
+/**
+ * Convert a string to the hex representation of its bcrypt hash
+ */
+std::string bcrypt(const std::string&);
 
 #endif // HASH_HPP_INCLUDED

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -8,6 +8,7 @@
 #define HASH_HPP_INCLUDED
 
 #include <string>
+#include "util/secure_string.hpp"
 
 enum HashFunc
 {
@@ -16,19 +17,42 @@ enum HashFunc
     BCRYPT = 2
 };
 
+class Hasher
+{
+public:
+    HashFunc hashFunc;
+
+    Hasher(HashFunc hashFunc) : hashFunc(hashFunc) { }
+
+    virtual std::string hash(const std::string& input) const = 0;
+    virtual bool check(const std::string& toCheck, const std::string& hashed) const = 0;
+
+    static util::secure_string SaltPassword(const std::string& salt, const std::string& username, util::secure_string&& password)
+    {
+        return util::secure_string(salt + username + std::move(password.str()));
+    }
+};
+
 /**
  * Convert a string to the hex representation of its sha256 hash
  */
-std::string sha256(const std::string& input, const std::string& salt);
+class Sha256Hasher : public Hasher {
+public:
+    Sha256Hasher() : Hasher(SHA256) { }
 
-/**
- * Generate a salt compatible with the bcrypt APIs
- */
-int bcrypt_generatesalt(char * salt, int workfactor = 12);
+    virtual std::string hash(const std::string& input) const override;
+    virtual bool check(const std::string& toCheck, const std::string& hashed) const override;
+};
 
 /**
  * Convert a string to a bcrypt hash
  */
-std::string bcrypt(const std::string& input, const std::string& salt);
+class BcryptHasher : public Hasher {
+public:
+    BcryptHasher() : Hasher(BCRYPT) { }
+
+    virtual std::string hash(const std::string& input) const override;
+    virtual bool check(const std::string& toCheck, const std::string& hashed) const override;
+};
 
 #endif // HASH_HPP_INCLUDED

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -48,8 +48,11 @@ public:
  * Convert a string to a bcrypt hash
  */
 class BcryptHasher : public Hasher {
+private:
+    int _workload;
+
 public:
-    BcryptHasher() : Hasher(BCRYPT) { }
+    BcryptHasher(int workload) : Hasher(BCRYPT), _workload(workload) { }
 
     virtual std::string hash(const std::string& input) const override;
     virtual bool check(const std::string& toCheck, const std::string& hashed) const override;

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -18,11 +18,16 @@ enum HashFunc
 /**
  * Convert a string to the hex representation of its sha256 hash
  */
-std::string sha256(const std::string&);
+std::string sha256(const std::string& input, const std::string& salt);
 
 /**
- * Convert a string to the hex representation of its bcrypt hash
+ * Generate a salt compatible with the bcrypt APIs
  */
-std::string bcrypt(const std::string&);
+int bcrypt_generatesalt(char * salt, int workfactor = 12);
+
+/**
+ * Convert a string to a bcrypt hash
+ */
+std::string bcrypt(const std::string& input, const std::string& salt);
 
 #endif // HASH_HPP_INCLUDED

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -20,7 +20,7 @@ enum HashFunc
 class Hasher
 {
 public:
-    HashFunc hashFunc;
+    const HashFunc hashFunc;
 
     Hasher(HashFunc hashFunc) : hashFunc(hashFunc) { }
 

--- a/src/hashupdater.cpp
+++ b/src/hashupdater.cpp
@@ -1,0 +1,113 @@
+#include "hashupdater.hpp"
+#include "world.hpp"
+
+PasswordHashUpdater::PasswordHashUpdater(World * world)
+    : world(world)
+    , _terminating(false)
+    , updateThread([this] { this->updateThreadProc(); })
+{
+}
+
+PasswordHashUpdater::~PasswordHashUpdater()
+{
+    this->_terminating = true;
+
+    this->updateSignal.notify_all();
+    this->updateThread.join();
+}
+
+void PasswordHashUpdater::QueueUpdatePassword(const std::string& username, const util::secure_string& password, HashFunc hashFunc)
+{
+    UpdateState state(username, password, hashFunc);
+
+    std::lock_guard<std::mutex> queueGuard(this->updateQueueLock);
+    this->updateQueue.push_back(state);
+}
+
+void PasswordHashUpdater::SignalUpdatePassword(const std::string& username)
+{
+    {
+        std::lock_guard<std::mutex> queueGuard(this->updateQueueLock);
+        this->ready_names.push_back(username);
+    }
+
+    this->updateSignal.notify_one();
+}
+
+PasswordHashUpdater::UpdateState::UpdateState(const std::string& username, const util::secure_string& password, HashFunc hashFunc)
+    : username(username)
+    , password(std::move(password))
+    , hashFunc(hashFunc)
+{
+}
+
+PasswordHashUpdater::UpdateState::UpdateState(const PasswordHashUpdater::UpdateState& other)
+    : username(other.username)
+    , password(std::move(other.password))
+    , hashFunc(other.hashFunc)
+{
+}
+
+PasswordHashUpdater::UpdateState& PasswordHashUpdater::UpdateState::operator=(const PasswordHashUpdater::UpdateState& rhs)
+{
+    if (this != &rhs)
+    {
+        this->username = rhs.username;
+        this->password = rhs.password;
+        this->hashFunc = rhs.hashFunc;
+    }
+
+    return *this;
+}
+
+void PasswordHashUpdater::updateThreadProc()
+{
+    while (!this->_terminating)
+    {
+        std::unique_lock<std::mutex> lock(this->updateMutex);
+        this->updateSignal.wait(lock);
+
+        if (this->_terminating)
+        {
+            break;
+        }
+
+        std::list<UpdateState> updateStates;
+
+        {
+            std::lock_guard<std::mutex> queueGuard(this->updateQueueLock);
+
+            if (this->updateQueue.empty())
+            {
+                this->ready_names.clear();
+                continue;
+            }
+
+            for (const auto& readyName : this->ready_names)
+            {
+                auto updateStateIter = std::find_if(
+                    this->updateQueue.begin(),
+                    this->updateQueue.end(),
+                    [&readyName](UpdateState& s) { return s.username == readyName; });
+
+                if (updateStateIter != this->updateQueue.end())
+                {
+                    updateStates.push_back(*updateStateIter);
+                    this->updateQueue.erase(updateStateIter);
+                }
+            }
+
+            this->ready_names.clear();
+        }
+
+        for (auto& updateState : updateStates)
+        {
+            util::secure_string updatedPassword = std::move(this->world->HashPassword(updateState.username, std::move(updateState.password), false));
+
+            this->world->db.Query("UPDATE `accounts` SET `password` = '$', `password_version` = # WHERE `username` = '$'",
+                updatedPassword.str().c_str(),
+                updateState.username,
+                updateState.hashFunc);
+        }
+    }
+}

--- a/src/hashupdater.cpp
+++ b/src/hashupdater.cpp
@@ -66,7 +66,7 @@ void PasswordHashUpdater::updateThreadProc()
         }
 
         std::string username;
-        util::secure_string updatedPassword = "";
+        util::secure_string updatedPassword("");
         HashFunc hashFunc = NONE;
 
         {

--- a/src/hashupdater.hpp
+++ b/src/hashupdater.hpp
@@ -1,3 +1,9 @@
+
+/* $Id$
+ * EOSERV is released under the zlib license.
+ * See LICENSE.txt for more info.
+ */
+
 #pragma once
 
 #include <condition_variable>
@@ -8,6 +14,7 @@
 #include "hash.hpp"
 #include "fwd/database.hpp"
 #include "util/secure_string.hpp"
+#include "util/semaphore.hpp"
 
 class PasswordHashUpdater
 {
@@ -35,9 +42,7 @@ private:
     };
 
     std::thread _updateThread;
-
-    std::mutex _updateMutex;
-    std::condition_variable _updateSignal;
+    util::Semaphore _updateSem;
 
     std::mutex _updateQueueLock;
     std::queue<UpdateState> _updateQueue;

--- a/src/hashupdater.hpp
+++ b/src/hashupdater.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <condition_variable>
+#include <list>
+#include <string>
+#include <thread>
+
+#include "hash.hpp"
+#include "fwd/world.hpp"
+#include "util/secure_string.hpp"
+
+class PasswordHashUpdater
+{
+public:
+    PasswordHashUpdater(World * world);
+    ~PasswordHashUpdater();
+
+    void QueueUpdatePassword(const std::string& username, const util::secure_string& password, HashFunc hashFunc);
+    void SignalUpdatePassword(const std::string& username);
+
+private:
+    World * world;
+
+    volatile bool _terminating;
+
+    struct UpdateState
+    {
+        std::string username;
+        util::secure_string password;
+        HashFunc hashFunc;
+
+        UpdateState(const UpdateState& other);
+        UpdateState(const std::string& username, const util::secure_string& password, HashFunc hashFunc);
+        UpdateState& operator=(const UpdateState& rhs);
+    };
+
+    std::thread updateThread;
+
+    std::mutex updateMutex;
+    std::condition_variable updateSignal;
+
+    std::list<std::string> ready_names;
+
+    std::mutex updateQueueLock;
+    std::list<UpdateState> updateQueue;
+
+    void updateThreadProc();
+};

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -97,12 +97,7 @@ bool Player::AddCharacter(std::string name, Gender gender, int hairstyle, int ha
 
 void Player::ChangePass(util::secure_string&& password)
 {
-	{
-		util::secure_string password_buffer(std::move(std::string(this->world->config["PasswordSalt"]) + this->username + password.str()));
-		password = sha256(password_buffer.str());
-	}
-
-	this->world->db.Query("UPDATE `accounts` SET `password` = '$' WHERE username = '$'", password.str().c_str(), this->username.c_str());
+	this->world->ChangePassword(this->username, std::move(password));
 }
 
 AdminLevel Player::Admin() const

--- a/src/util/semaphore.cpp
+++ b/src/util/semaphore.cpp
@@ -1,0 +1,40 @@
+
+/* $Id$
+ * EOSERV is released under the zlib license.
+ * See LICENSE.txt for more info.
+ */
+
+#include "semaphore.hpp"
+
+namespace util
+{
+
+void Semaphore::Wait()
+{
+    std::unique_lock<std::mutex> lock(this->_mut);
+    this->_event.wait(lock, [&]() { return _count > 0; });
+    --this->_count;
+}
+
+template <class _Rep, class _Period>
+bool Semaphore::Wait(std::chrono::duration<_Rep, _Period> timeout)
+{
+    std::unique_lock<std::mutex> lock(this->_mut);
+    if (!this->_event.wait_for(lock, timeout, [&]() { return _count > 0; }))
+    {
+        return false;
+    }
+
+    --this->_count;
+
+    return true;
+}
+
+void Semaphore::Release(size_t count)
+{
+    std::unique_lock<std::mutex> lock(this->_mut);
+    this->_count += count;
+    this->_event.notify_one();
+}
+
+}

--- a/src/util/semaphore.hpp
+++ b/src/util/semaphore.hpp
@@ -21,7 +21,7 @@ public:
 
     void Wait();
 
-    template <class _Rep = __int64, class _Period = std::milli>
+    template <class _Rep = long long, class _Period = std::milli>
     bool Wait(std::chrono::duration<_Rep, _Period> timeout);
 
     void Release(size_t count = 1);

--- a/src/util/semaphore.hpp
+++ b/src/util/semaphore.hpp
@@ -1,0 +1,35 @@
+
+/* $Id$
+ * EOSERV is released under the zlib license.
+ * See LICENSE.txt for more info.
+ */
+
+#pragma once
+
+#include <condition_variable>
+
+namespace util
+{
+
+class Semaphore
+{
+public:
+    Semaphore(size_t initialCount) : _count(initialCount) { }
+
+    Semaphore(const Semaphore&) = delete;
+    Semaphore(Semaphore&& other) = delete;
+
+    void Wait();
+
+    template <class _Rep = __int64, class _Period = std::milli>
+    bool Wait(std::chrono::duration<_Rep, _Period> timeout);
+
+    void Release(size_t count = 1);
+
+private:
+    size_t _count;
+    std::condition_variable _event;
+    std::mutex _mut;
+};
+
+}

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -427,7 +427,7 @@ World::World(std::array<std::string, 6> dbinfo, const Config &eoserv_config, con
 	this->BeginDB();
 
 	this->passwordHashers[SHA256].reset(new Sha256Hasher());
-	this->passwordHashers[BCRYPT].reset(new BcryptHasher());
+	this->passwordHashers[BCRYPT].reset(new BcryptHasher(int(this->config["BcryptWorkload"])));
 	this->passwordHashUpdater.reset(new PasswordHashUpdater(this->config, this->passwordHashers));
 
 	try

--- a/src/world.hpp
+++ b/src/world.hpp
@@ -24,6 +24,7 @@
 #include "i18n.hpp"
 #include "hash.hpp"
 #include "map.hpp"
+#include "hashupdater.hpp"
 #include "timer.hpp"
 
 #include "fwd/socket.hpp"
@@ -80,6 +81,9 @@ class World
 
 		std::string bcrypt_salt;
 		util::secure_string HashPassword(const std::string& username, util::secure_string&& password, bool isLoginAttempt);
+
+		friend class PasswordHashUpdater;
+		std::unique_ptr<PasswordHashUpdater> passwordHashUpdater;
 
 	protected:
 		int last_character_id;

--- a/src/world.hpp
+++ b/src/world.hpp
@@ -76,13 +76,7 @@ struct Home
 class World
 {
 	private:
-		typedef std::string (*PasswordHashFn)(const std::string& input, const std::string& salt);
-		std::unordered_map<HashFunc, PasswordHashFn> passwordVersionMap;
-
-		std::string bcrypt_salt;
-		util::secure_string HashPassword(const std::string& username, util::secure_string&& password, bool isLoginAttempt);
-
-		friend class PasswordHashUpdater;
+		std::unordered_map<HashFunc, std::shared_ptr<Hasher>> passwordHashers;
 		std::unique_ptr<PasswordHashUpdater> passwordHashUpdater;
 
 	protected:

--- a/src/world.hpp
+++ b/src/world.hpp
@@ -78,7 +78,7 @@ class World
 		typedef std::string (*PasswordHashFn)(const std::string&);
 		std::unordered_map<HashFunc, PasswordHashFn> passwordVersionMap;
 
-		util::secure_string&& HashPassword(const std::string& username, util::secure_string&& password, bool isLoginAttempt);
+		util::secure_string HashPassword(const std::string& username, util::secure_string&& password, bool isLoginAttempt);
 
 	protected:
 		int last_character_id;

--- a/src/world.hpp
+++ b/src/world.hpp
@@ -75,9 +75,10 @@ struct Home
 class World
 {
 	private:
-		typedef std::string (*PasswordHashFn)(const std::string&);
+		typedef std::string (*PasswordHashFn)(const std::string& input, const std::string& salt);
 		std::unordered_map<HashFunc, PasswordHashFn> passwordVersionMap;
 
+		std::string bcrypt_salt;
 		util::secure_string HashPassword(const std::string& username, util::secure_string&& password, bool isLoginAttempt);
 
 	protected:

--- a/src/world.hpp
+++ b/src/world.hpp
@@ -22,6 +22,7 @@
 #include "config.hpp"
 #include "database.hpp"
 #include "i18n.hpp"
+#include "hash.hpp"
 #include "map.hpp"
 #include "timer.hpp"
 
@@ -73,6 +74,12 @@ struct Home
  */
 class World
 {
+	private:
+		typedef std::string (*PasswordHashFn)(const std::string&);
+		std::unordered_map<HashFunc, PasswordHashFn> passwordVersionMap;
+
+		util::secure_string&& HashPassword(const std::string& username, util::secure_string&& password, bool isLoginAttempt);
+
 	protected:
 		int last_character_id;
 
@@ -176,6 +183,7 @@ class World
 		Player *Login(const std::string& username, util::secure_string&& password);
 		Player *Login(std::string username);
 		LoginReply LoginCheck(const std::string& username, util::secure_string&& password);
+		void ChangePassword(const std::string& username, util::secure_string&& password);
 
 		bool CreatePlayer(const std::string& username, util::secure_string&& password,
 			const std::string& fullname,const std::string& location, const std::string& email,

--- a/tu/system.cpp
+++ b/tu/system.cpp
@@ -15,6 +15,7 @@
 #include "../src/timer.cpp"
 #include "../src/util.cpp"
 #include "../src/util/rpn.cpp"
+#include "../src/util/semaphore.cpp"
 #include "../src/util/variant.cpp"
 
 #ifdef WIN32

--- a/tu/system.cpp
+++ b/tu/system.cpp
@@ -8,6 +8,7 @@
 #include "../src/console.cpp"
 #include "../src/database.cpp"
 #include "../src/hash.cpp"
+#include "../src/hashupdater.cpp"
 #include "../src/i18n.cpp"
 #include "../src/nanohttp.cpp"
 #include "../src/socket.cpp"

--- a/upgrade/0.7.0_to_0.7.1.sql
+++ b/upgrade/0.7.0_to_0.7.1.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `accounts`
+    ADD COLUMN `password_version` INTEGER DEFAULT 1 NOT NULL

--- a/upgrade/0.7.0_to_0.7.1.sql
+++ b/upgrade/0.7.0_to_0.7.1.sql
@@ -1,2 +1,3 @@
 ALTER TABLE `accounts`
-    ADD COLUMN `password_version` INTEGER DEFAULT 1 NOT NULL
+    ALTER COLUMN `password` VARCHAR(64) NOT NULL,
+    ADD COLUMN `password_version` INTEGER DEFAULT 1 NOT NULL;

--- a/upgrade/0.7.0_to_0.7.1_sqlserver.sql
+++ b/upgrade/0.7.0_to_0.7.1_sqlserver.sql
@@ -1,2 +1,3 @@
 ALTER TABLE [accounts]
-    ADD [password_version] INTEGER DEFAULT 1 NOT NULL
+    ALTER COLUMN [password] VARCHAR(64) NOT NULL,
+    ADD [password_version] INTEGER DEFAULT 1 NOT NULL;

--- a/upgrade/0.7.0_to_0.7.1_sqlserver.sql
+++ b/upgrade/0.7.0_to_0.7.1_sqlserver.sql
@@ -1,3 +1,5 @@
 ALTER TABLE [accounts]
-    ALTER COLUMN [password] VARCHAR(64) NOT NULL,
+    ALTER COLUMN [password] VARCHAR(64) NOT NULL;
+
+ALTER TABLE [accounts]
     ADD [password_version] INTEGER DEFAULT 1 NOT NULL;

--- a/upgrade/0.7.0_to_0.7.1_sqlserver.sql
+++ b/upgrade/0.7.0_to_0.7.1_sqlserver.sql
@@ -1,0 +1,2 @@
+ALTER TABLE [accounts]
+    ADD [password_version] INTEGER DEFAULT 1 NOT NULL


### PR DESCRIPTION
Add support for versioned passwords. This allows implementing different password hashes with ease and versioning them in the database. The latest password version is stored (right now 1 == sha256, 2 == bcrypt) along with the hashed password.

As this requires a schema update to the database, I'm unofficially calling this v0.7.1.

Bcrypt implementation is https://github.com/trusch/libbcrypt, downloaded via CMake.

Password versions are updated on login in a background thread. A separate database connection is used for background thread updates.

This addresses [issue 431](https://eoserv.net/bugs/view_bug/431) on the eoserv bug tracker.