### PR TITLE
Add threadpool for queueing of background operations asynchronously

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -99,6 +99,104 @@
                 "databaseFilename": ""
             },
             "intelliSenseMode": "gcc-x64"
+        },
+        {
+            "name": "SqlServer - Windows (Debug)",
+            "includePath": [
+                "build/googletest-src/googletest/include",
+                "build/googletest-src/googlemock/include",
+                "build/bcrypt-src/include",
+                "src"
+            ],
+            "defines": [
+                "DATABASE_SQLSERVER",
+                "DEBUG"
+            ],
+            "compilerPath": "\"${myCompilerPath}cl.exe\"",
+            "cStandard": "c11",
+            "cppStandard": "c++11",
+            "browse": {
+                "path": [
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "intelliSenseMode": "msvc-x64"
+        },
+        {
+            "name": "MySQL + SqlServer - Windows (Debug)",
+            "includePath": [
+                "build/googletest-src/googletest/include",
+                "build/googletest-src/googlemock/include",
+                "build/bcrypt-src/include",
+                "src"
+            ],
+            "defines": [
+                "DATABASE_SQLSERVER",
+                "DATABASE_MYSQL",
+                "DEBUG"
+            ],
+            "compilerPath": "\"${myCompilerPath}cl.exe\"",
+            "cStandard": "c11",
+            "cppStandard": "c++11",
+            "browse": {
+                "path": [
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "intelliSenseMode": "msvc-x64"
+        },
+        {
+            "name": "SqlServer - Linux (Debug)",
+            "includePath": [
+                "build/googletest-src/googletest/include",
+                "build/googletest-src/googlemock/include",
+                "build/bcrypt-src/include",
+                "src"
+            ],
+            "defines": [
+                "DATABASE_SQLSERVER",
+                "DEBUG"
+            ],
+            "compilerPath": "/usr/bin/g++",
+            "cStandard": "c11",
+            "cppStandard": "c++11",
+            "browse": {
+                "path": [
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "intelliSenseMode": "gcc-x64"
+        },
+        {
+            "name": "MySQL + SqlServer - Linux (Debug)",
+            "includePath": [
+                "build/googletest-src/googletest/include",
+                "build/googletest-src/googlemock/include",
+                "build/bcrypt-src/include",
+                "src"
+            ],
+            "defines": [
+                "DATABASE_SQLSERVER",
+                "DATABASE_MYSQL",
+                "DEBUG"
+            ],
+            "compilerPath": "/usr/bin/g++",
+            "cStandard": "c11",
+            "cppStandard": "c++11",
+            "browse": {
+                "path": [
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "intelliSenseMode": "gcc-x64"
         }
     ],
     "version": 4

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,18 @@
             "externalConsole": true
         },
         {
+            "name": "Debug - Tests - Windows",
+            "preLaunchTask": "Build (Windows) - Debug",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/install/test/eoserv_test",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/install/test",
+            "environment": [],
+            "externalConsole": true
+        },
+        {
             "name": "Debug - Linux",
             "preLaunchTask": "Build (Linux) - Debug",
             "type": "cppvsdbg",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,10 @@ endif()
 
 if(EOSERV_USE_UNITY_BUILD)
 	set(eoserv_SOURCE_FILES ${eoserv_UNITY_SOURCE_FILES})
-	set(eoserv_MAIN_FILES tu/main.cpp)
+	set(eoserv_MAIN_FILES ${eoserv_UNITY_HANDLER_FILES} tu/main.cpp)
 else()
 	set(eoserv_SOURCE_FILES ${eoserv_ALL_SOURCE_FILES})
-	set(eoserv_MAIN_FILES src/main.cpp)
+	set(eoserv_MAIN_FILES ${eoserv_ALL_HANDLER_FILES} src/main.cpp)
 endif()
 
 # Fancy icon on Windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,11 +92,16 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 
 	# Fix warnings due to not using the _s version of a lot of different functions on MSVC
 	#
-	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 
 	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14.0")
 		set(eoserv_COMPILER_SUPPORTED FALSE)
 	endif()
+
+	add_compile_definitions(
+		$<$<CONFIG:Debug>:DEBUG>
+		$<$<CONFIG:Release>:RELEASE>
+	)
 endif()
 
 if((eoserv_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0")
@@ -139,18 +144,18 @@ if(EOSERV_USE_CLANG_MODULES)
 		endif()
 
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fmodules")
-		add_definitions(-DCLANG_MODULES_WORKAROUND)
+		add_compile_definitions(CLANG_MODULES_WORKAROUND)
 	endif()
 endif()
 
 if(EOSERV_DEBUG_QUERIES)
-	add_definitions(-DDATABASE_DEBUG)
+	add_compile_definitions(DATABASE_DEBUG)
 endif()
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" BuildType)
 
 if(BuildType STREQUAL "debug")
-	add_definitions(-DDEBUG)
+	add_compile_definitions(DEBUG)
 
 	# Disable optimizations for debug builds with GCC.
 	IF(CMAKE_COMPILER_IS_GNUCC)
@@ -192,7 +197,7 @@ if(EOSERV_WANT_MYSQL)
 	find_package(MariaDB REQUIRED)
 	include_directories(${MARIADB_INCLUDE_DIR})
 	list(APPEND eoserv_LIBRARIES ${MARIADB_LIBRARY})
-	add_definitions(-DDATABASE_MYSQL)
+	add_compile_definitions(DATABASE_MYSQL)
 endif()
 
 if(EOSERV_WANT_SQLITE)
@@ -205,14 +210,14 @@ if(EOSERV_WANT_SQLITE)
 		list(APPEND eoserv_LIBRARIES ${SQLITE3_LIBRARY})
 	endif()
 
-	add_definitions(-DDATABASE_SQLITE)
+	add_compile_definitions(DATABASE_SQLITE)
 endif()
 
 if(EOSERV_WANT_SQLSERVER)
 	find_package(ODBC REQUIRED)
 	include_directories(${ODBC_INCLUDE_DIRS})
 	list(APPEND eoserv_LIBRARIES ${ODBC_LIBRARIES})
-	add_definitions(-DDATABASE_SQLSERVER)
+	add_compile_definitions(DATABASE_SQLSERVER)
 endif()
 
 if (NOT EOSERV_WANT_MYSQL AND NOT EOSERV_WANT_SQLITE AND NOT EOSERV_WANT_SQLSERVER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,13 +40,16 @@ endif()
 
 if(EOSERV_USE_UNITY_BUILD)
 	set(eoserv_SOURCE_FILES ${eoserv_UNITY_SOURCE_FILES})
+	set(eoserv_MAIN_FILES tu/main.cpp)
 else()
 	set(eoserv_SOURCE_FILES ${eoserv_ALL_SOURCE_FILES})
+	set(eoserv_MAIN_FILES src/main.cpp)
 endif()
 
 # Fancy icon on Windows
 if(WIN32)
-	list(APPEND eoserv_SOURCE_FILES "project/winres.rc")
+	list(APPEND eoserv_MAIN_FILES "project/winres.rc")
+	list(APPEND eoserv_MAIN_FILES ${eoserv_WIN32_SOURCE_FILES_MAIN})
 
 	# Link directly to SQLite on Windows
 	if(EOSERV_WANT_SQLITE)
@@ -166,15 +169,12 @@ include(DownloadGoogleTest)
 #  Outputs
 # ---------
 
-add_executable(eoserv
-	${eoserv_SOURCE_FILES}
-)
+add_library(eoserv_lib STATIC ${eoserv_SOURCE_FILES})
+add_executable(eoserv ${eoserv_MAIN_FILES})
+add_executable(eoserv_test ${TestFiles})
 
-add_executable(eoserv_test
-	${TestFiles}
-)
 target_include_directories(eoserv_test PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(eoserv_test gtest_main)
+target_link_libraries(eoserv_test gtest_main eoserv_lib)
 
 if(EOSERV_USE_PRECOMPILED_HEADERS)
 	add_dependencies(eoserv_test eoserv-pch)
@@ -232,9 +232,11 @@ endif()
 include(DownloadBcrypt)
 
 target_include_directories(eoserv PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
+target_include_directories(eoserv_lib PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
 list(APPEND eoserv_LIBRARIES bcrypt)
 
-target_link_libraries(eoserv ${eoserv_LIBRARIES})
+target_link_libraries(eoserv eoserv_lib ${eoserv_LIBRARIES})
+target_link_libraries(eoserv_lib ${eoserv_LIBRARIES})
 
 install(TARGETS eoserv RUNTIME DESTINATION .)
 install(TARGETS eoserv_test RUNTIME DESTINATION ./test)
@@ -282,6 +284,7 @@ if(EOSERV_USE_PRECOMPILED_HEADERS)
 
 	add_dependencies(eoserv-pch-autogen eoserv-pch)
 	add_dependencies(eoserv eoserv-pch)
+	add_dependencies(eoserv_lib eoserv-pch)
 
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${eoserv-pch_INCLUDE_FLAG}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ target_include_directories(eoserv PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
 target_include_directories(eoserv_lib PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
 list(APPEND eoserv_LIBRARIES bcrypt)
 
-target_link_libraries(eoserv eoserv_lib ${eoserv_LIBRARIES})
+target_link_libraries(eoserv eoserv_lib)
 target_link_libraries(eoserv_lib ${eoserv_LIBRARIES})
 
 install(TARGETS eoserv RUNTIME DESTINATION .)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ endif()
 
 # These non-standard anti-optimizations are currently required for a correctly functioning server
 if(eoserv_GCC OR eoserv_CLANG)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fwrapv -fno-strict-aliasing")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fwrapv -fno-strict-aliasing -Wall -Wextra")
 endif()
 
 if(NOT eoserv_COMPILER_SUPPORTED)

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -45,8 +45,8 @@ function main() {
         sqlite="$2"
         shift
         ;;
-      --maria)
-        sqlite="$2"
+      --mariadb)
+        mariadb="$2"
         shift
         ;;
       --sqlserver)

--- a/build-windows.ps1
+++ b/build-windows.ps1
@@ -57,7 +57,22 @@ if ($Debug) {
 }
 
 cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -G "Visual Studio 15 2017" ..
+$tmpResult=$?
+if (-not $tmpResult)
+{
+    Set-Location $PSScriptRoot
+    Write-Error "Error during cmake generation!"
+    exit $tmpResult
+}
+
 cmake --build . --config $buildMode --target INSTALL --
+$tmpResult=$?
+if (-not $tmpResult)
+{
+    Set-Location $PSScriptRoot
+    Write-Error "Error during cmake build!"
+    exit $tmpResult
+}
 
 Set-Location $PSScriptRoot
 

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -169,6 +169,8 @@ set(eoserv_ALL_SOURCE_FILES
 	src/util/secure_string.hpp
 	src/util/semaphore.cpp
 	src/util/semaphore.hpp
+	src/util/threadpool.cpp
+	src/util/threadpool.hpp
 	src/util/variant.cpp
 	src/util/variant.hpp
 	src/version.h

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -3,7 +3,6 @@
 # See LICENSE.txt for more info.
 
 set(eoserv_UNITY_SOURCE_FILES
-	tu/main.cpp
 	tu/system.cpp
 	tu/game_1.cpp
 	tu/game_2.cpp
@@ -135,7 +134,6 @@ set(eoserv_ALL_SOURCE_FILES
 	src/hashupdater.hpp
 	src/i18n.cpp
 	src/i18n.hpp
-	src/main.cpp
 	src/map.cpp
 	src/map.hpp
 	src/nanohttp.cpp
@@ -180,6 +178,9 @@ set(eoserv_ALL_SOURCE_FILES
 
 set(eoserv_WIN32_SOURCE_FILES
 	src/eoserv_windows.h
+)
+
+set(eoserv_WIN32_SOURCE_FILES_MAIN
 	src/extra/ntservice.cpp
 	src/extra/ntservice.hpp
 )

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -7,10 +7,13 @@ set(eoserv_UNITY_SOURCE_FILES
 	tu/game_1.cpp
 	tu/game_2.cpp
 	tu/game_3.cpp
-	tu/handlers.cpp
-	tu/commands.cpp
 	tu/eoplus.cpp
 	tu/sha256.c
+)
+
+set(eoserv_UNITY_HANDLER_FILES
+	tu/handlers.cpp
+	tu/commands.cpp
 )
 
 set(eoserv_ALL_SOURCE_FILES
@@ -20,16 +23,8 @@ set(eoserv_ALL_SOURCE_FILES
 	src/character.hpp
 	src/command_source.cpp
 	src/command_source.hpp
-	src/commands/admin.cpp
-	src/commands/char_mod.cpp
 	src/commands/commands.cpp
 	src/commands/commands.hpp
-	src/commands/debug.cpp
-	src/commands/info.cpp
-	src/commands/map.cpp
-	src/commands/moderation.cpp
-	src/commands/server.cpp
-	src/commands/warp.cpp
 	src/config.cpp
 	src/config.hpp
 	src/console.cpp
@@ -88,46 +83,8 @@ set(eoserv_ALL_SOURCE_FILES
 	src/fwd/world.hpp
 	src/guild.cpp
 	src/guild.hpp
-	src/handlers/Account.cpp
-	src/handlers/AdminInteract.cpp
-	src/handlers/Attack.cpp
-	src/handlers/Bank.cpp
-	src/handlers/Barber.cpp
-	src/handlers/Board.cpp
-	src/handlers/Book.cpp
-	src/handlers/Chair.cpp
-	src/handlers/Character.cpp
-	src/handlers/Chest.cpp
-	src/handlers/Citizen.cpp
-	src/handlers/Connection.cpp
-	src/handlers/Door.cpp
-	src/handlers/Emote.cpp
-	src/handlers/Face.cpp
-	src/handlers/Global.cpp
-	src/handlers/Guild.cpp
 	src/handlers/handlers.cpp
 	src/handlers/handlers.hpp
-	src/handlers/Init.cpp
-	src/handlers/Internal.cpp
-	src/handlers/Item.cpp
-	src/handlers/Jukebox.cpp
-	src/handlers/Locker.cpp
-	src/handlers/Login.cpp
-	src/handlers/Message.cpp
-	src/handlers/Paperdoll.cpp
-	src/handlers/Party.cpp
-	src/handlers/Players.cpp
-	src/handlers/Quest.cpp
-	src/handlers/Refresh.cpp
-	src/handlers/Shop.cpp
-	src/handlers/Sit.cpp
-	src/handlers/Spell.cpp
-	src/handlers/StatSkill.cpp
-	src/handlers/Talk.cpp
-	src/handlers/Trade.cpp
-	src/handlers/Walk.cpp
-	src/handlers/Warp.cpp
-	src/handlers/Welcome.cpp
 	src/hash.cpp
 	src/hash.hpp
 	src/hashupdater.cpp
@@ -174,6 +131,55 @@ set(eoserv_ALL_SOURCE_FILES
 	src/version.h
 	src/world.cpp
 	src/world.hpp
+)
+
+set(eoserv_ALL_HANDLER_FILES
+	src/commands/admin.cpp
+	src/commands/char_mod.cpp
+	src/commands/debug.cpp
+	src/commands/info.cpp
+	src/commands/map.cpp
+	src/commands/moderation.cpp
+	src/commands/server.cpp
+	src/commands/warp.cpp
+	src/handlers/Account.cpp
+	src/handlers/AdminInteract.cpp
+	src/handlers/Attack.cpp
+	src/handlers/Bank.cpp
+	src/handlers/Barber.cpp
+	src/handlers/Board.cpp
+	src/handlers/Book.cpp
+	src/handlers/Chair.cpp
+	src/handlers/Character.cpp
+	src/handlers/Chest.cpp
+	src/handlers/Citizen.cpp
+	src/handlers/Connection.cpp
+	src/handlers/Door.cpp
+	src/handlers/Emote.cpp
+	src/handlers/Face.cpp
+	src/handlers/Global.cpp
+	src/handlers/Guild.cpp
+	src/handlers/Init.cpp
+	src/handlers/Internal.cpp
+	src/handlers/Item.cpp
+	src/handlers/Jukebox.cpp
+	src/handlers/Locker.cpp
+	src/handlers/Login.cpp
+	src/handlers/Message.cpp
+	src/handlers/Paperdoll.cpp
+	src/handlers/Party.cpp
+	src/handlers/Players.cpp
+	src/handlers/Quest.cpp
+	src/handlers/Refresh.cpp
+	src/handlers/Shop.cpp
+	src/handlers/Sit.cpp
+	src/handlers/Spell.cpp
+	src/handlers/StatSkill.cpp
+	src/handlers/Talk.cpp
+	src/handlers/Trade.cpp
+	src/handlers/Walk.cpp
+	src/handlers/Warp.cpp
+	src/handlers/Welcome.cpp
 )
 
 set(eoserv_WIN32_SOURCE_FILES

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -269,6 +269,7 @@ set(ExtraFiles
 set(TestFiles
 	src/test/config_test.cpp
 	src/test/util/semaphore_test.cpp
+	src/test/util/threadpool_test.cpp
 )
 
 set(LocalConf

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -268,6 +268,7 @@ set(ExtraFiles
 
 set(TestFiles
 	src/test/config_test.cpp
+	src/test/util/semaphore_test.cpp
 )
 
 set(LocalConf

--- a/config/server.ini
+++ b/config/server.ini
@@ -143,5 +143,6 @@ IgnorePacketFamilies = *
 InitLoginBan = yes
 
 ## ThreadPoolThreads (int)
-# Number of background threads in the thread pool. A value of 0 defaults to the number of CPUs on the system
+# Number of background threads in the thread pool
+# A value of 0 defaults to the number of concurrent threads supported by the implementation
 ThreadPoolThreads = 0

--- a/config/server.ini
+++ b/config/server.ini
@@ -141,3 +141,7 @@ IgnorePacketFamilies = *
 # Sends an INIT packet as a response when the login attempt comes from a banned user
 # When disabled, sends a LoginReply enum value instead
 InitLoginBan = yes
+
+## ThreadPoolThreads (int)
+# Number of background threads in the thread pool. A value of 0 defaults to the number of CPUs on the system
+ThreadPoolThreads = 0

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -54,7 +54,7 @@ if [ -z "$PLATFORM_NAME" ]; then
     fi
 fi
 
-SUPPORTED_VERSIONS=" 14.04 16.04 18.04 18.10 19.04 6 7 8 "
+SUPPORTED_VERSIONS=" 14.04 16.04 18.04 18.10 19.04 20.04 6 7 8 "
 VERSION_IS_SUPPORTED=$(echo $SUPPORTED_VERSIONS | grep -oP " $PLATFORM_VERSION ")
 if [ -z "$PLATFORM_VERSION" ]; then
     >&2 echo "Unable to detect platform version! Check that /etc/os-release has a VERSION_ID= set."

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -499,7 +499,7 @@ Character::Character(std::string name, World *world)
 	}
 }
 
-int Character::PlayerID() const
+unsigned int Character::PlayerID() const
 {
 	return this->player->id;
 }

--- a/src/character.hpp
+++ b/src/character.hpp
@@ -292,7 +292,7 @@ class Character : public Command_Source
 		bool CanInteractCharMod() const { return !(nointeract & NoInteractCharMod); }
 		bool CanInteractPKCombat() const { return !(nointeract & NoInteractPKCombat); }
 
-		int PlayerID() const;
+		unsigned int PlayerID() const;
 
 		void Login();
 

--- a/src/commands/server.cpp
+++ b/src/commands/server.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-extern volatile std::sig_atomic_t eoserv_sig_abort;
+volatile std::sig_atomic_t eoserv_sig_abort = false;
 
 namespace Commands
 {

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -394,35 +394,26 @@ void Database::Close()
 
 	switch (this->engine)
 	{
+		case MySQL:
 #ifdef DATABASE_MYSQL
-		case SQLite:
-		case SqlServer:
-			break;
-		case MySQL:
 			mysql_close(this->impl->mysql_handle);
-			break;
 #endif // DATABASE_MYSQL
+			break;
 
+		case SQLite:
 #ifdef DATABASE_SQLITE
-		case MySQL:
-		case SqlServer:
-			break;
-		case SQLite:
 			sqlite3_close(this->impl->sqlite_handle);
-			break;
 #endif // DATABASE_SQLITE
-
-#ifdef DATABASE_SQLSERVER
-		case MySQL:
-		case SQLite:
 			break;
+
 		case SqlServer:
+#ifdef DATABASE_SQLSERVER
 			SQLFreeHandle(SQL_HANDLE_STMT, this->impl->hstmt);
 			SQLDisconnect(this->impl->hConn);
 			SQLFreeHandle(SQL_HANDLE_DBC, this->impl->hConn);
 			SQLFreeHandle(SQL_HANDLE_ENV, this->impl->hEnv);
-			break;
 #endif // DATABASE_SQLSERVER
+			break;
 	}
 }
 
@@ -834,11 +825,11 @@ Database_Result Database::Query(const char *format, ...)
 	va_end(ap);
 
 	std::string& finalquery = queryState.first;
-	std::list<std::string>& parameters = queryState.second;
-
 	bool prepared = false;
 
 #ifdef DATABASE_SQLSERVER
+	std::list<std::string>& parameters = queryState.second;
+
 	if (!parameters.empty())
 	{
 		prepared = true;

--- a/src/eoclient.cpp
+++ b/src/eoclient.cpp
@@ -163,7 +163,7 @@ void EOClient::Tick()
 					{
 						break;
 					}
-
+					// fall through
 				case EOClient::ReadLen2:
 					this->raw_length[1] = data[0];
 					data[0] = '\0';
@@ -175,7 +175,7 @@ void EOClient::Tick()
 					{
 						break;
 					}
-
+					// fall through
 				case EOClient::ReadData:
 					oldlength = this->data.length();
 					this->data += data.substr(0, this->length);

--- a/src/eoserv_config.cpp
+++ b/src/eoserv_config.cpp
@@ -270,6 +270,7 @@ void eoserv_config_validate_config(Config& config)
 	eoserv_config_default(config, "MaxTrade"           , 2000000000);
 	eoserv_config_default(config, "IgnorePacketFamilies", "*");
 	eoserv_config_default(config, "InitLoginBan"       , true);
+	eoserv_config_default(config, "ThreadPoolThreads"  , 0);
 }
 
 void eoserv_config_validate_admin(Config& config)

--- a/src/handlers/Account.cpp
+++ b/src/handlers/Account.cpp
@@ -89,7 +89,7 @@ void Account_Create(EOClient *client, PacketReader &reader)
 	{
 		hdid = static_cast<int>(util::to_uint_raw(reader.GetBreakString()));
 	}
-	catch (std::invalid_argument)
+	catch (std::invalid_argument&)
 	{
 		return;
 	}

--- a/src/handlers/Init.cpp
+++ b/src/handlers/Init.cpp
@@ -51,7 +51,7 @@ void Init_Init(EOClient *client, PacketReader &reader)
 	{
 		client->hdid = int(util::to_uint_raw(reader.GetEndString()));
 	}
-	catch (std::invalid_argument)
+	catch (std::invalid_argument&)
 	{
 		client->Close();
 		return;

--- a/src/handlers/Talk.cpp
+++ b/src/handlers/Talk.cpp
@@ -24,8 +24,6 @@
 #include <string>
 #include <vector>
 
-extern volatile std::sig_atomic_t eoserv_sig_abort;
-
 static void limit_message(std::string &message, std::size_t chatlength)
 {
 	if (message.length() > chatlength)

--- a/src/hashupdater.cpp
+++ b/src/hashupdater.cpp
@@ -5,18 +5,14 @@
  */
 
 #include "hashupdater.hpp"
-#include "util.hpp"
+#include "util/threadpool.hpp"
 #include "world.hpp"
 
 PasswordHashUpdater::PasswordHashUpdater(Config& config, const std::unordered_map<HashFunc, std::shared_ptr<Hasher>>& passwordHashers)
     : _config(config)
     , _passwordHashers(passwordHashers)
     , _database(nullptr)
-    , _terminating(false)
-    , _updateSem(0)
 {
-    this->_updateThread = std::thread([this] { this->updateThreadProc(); });
-
     auto dbType = util::lowercase(std::string(config["DBType"]));
 
     Database::Engine engine = Database::MySQL;
@@ -42,59 +38,20 @@ PasswordHashUpdater::PasswordHashUpdater(Config& config, const std::unordered_ma
     this->_database.reset(new Database(engine, dbHost, dbPort, dbUser, dbPass, dbName));
 }
 
-PasswordHashUpdater::~PasswordHashUpdater()
-{
-    this->_terminating = true;
-
-    this->_updateSem.Release();
-    this->_updateThread.join();
-}
-
 void PasswordHashUpdater::QueueUpdatePassword(const std::string& username, util::secure_string&& password, HashFunc hashFunc)
 {
-    UpdateState state { username, std::move(password), hashFunc };
-
-    std::lock_guard<std::mutex> queueGuard(this->_updateQueueLock);
-    this->_updateQueue.push(std::move(state));
-
-    this->_updateSem.Release();
-}
-
-void PasswordHashUpdater::updateThreadProc()
-{
-    while (!this->_terminating)
+    auto updateThreadProc = [this](const void * state)
     {
-        this->_updateSem.Wait();
+        auto updateState = reinterpret_cast<const PasswordHashUpdater::UpdateState*>(state);
 
-        if (this->_terminating)
-        {
-            break;
-        }
-
-        std::string username;
-        util::secure_string updatedPassword("");
-        HashFunc hashFunc = NONE;
-
-        {
-            std::lock_guard<std::mutex> queueGuard(this->_updateQueueLock);
-
-            if (this->_updateQueue.empty())
-            {
-                continue;
-            }
-
-            UpdateState updateState = std::move(this->_updateQueue.front());
-            this->_updateQueue.pop();
-
-            username = updateState.username;
-            updatedPassword = std::move(Hasher::SaltPassword(std::string(this->_config["PasswordSalt"]), username, std::move(updateState.password)));
-            hashFunc = updateState.hashFunc;
-        }
+        auto username = updateState->username;
+        auto updatedPassword = std::move(Hasher::SaltPassword(std::string(this->_config["PasswordSalt"]),
+                                                              username,
+                                                              std::move(const_cast<PasswordHashUpdater::UpdateState*>(updateState)->password)));
+        auto hashFunc = updateState->hashFunc;
 
         if (hashFunc == NONE)
-        {
-            continue;
-        }
+            return;
 
         updatedPassword = std::move(this->_passwordHashers[hashFunc]->hash(std::move(updatedPassword.str())));
 
@@ -102,5 +59,10 @@ void PasswordHashUpdater::updateThreadProc()
             updatedPassword.str().c_str(),
             hashFunc,
             username.c_str());
-    }
+
+        delete updateState;
+    };
+
+    auto state = reinterpret_cast<void*>(new UpdateState { username, std::move(password), hashFunc });
+    util::ThreadPool::Queue(updateThreadProc, state);
 }

--- a/src/hashupdater.hpp
+++ b/src/hashupdater.hpp
@@ -22,6 +22,7 @@ class PasswordHashUpdater
 {
 public:
     PasswordHashUpdater(Config &config, const std::unordered_map<HashFunc, std::shared_ptr<Hasher>>& passwordHashers);
+    ~PasswordHashUpdater();
 
     void QueueUpdatePassword(const std::string& username, util::secure_string&& password, HashFunc hashFunc);
 

--- a/src/hashupdater.hpp
+++ b/src/hashupdater.hpp
@@ -10,8 +10,10 @@
 #include <queue>
 #include <string>
 #include <thread>
+#include <unordered_map>
 
 #include "hash.hpp"
+#include "fwd/config.hpp"
 #include "fwd/database.hpp"
 #include "util/secure_string.hpp"
 #include "util/semaphore.hpp"

--- a/src/hashupdater.hpp
+++ b/src/hashupdater.hpp
@@ -26,10 +26,11 @@ public:
     void QueueUpdatePassword(const std::string& username, util::secure_string&& password, HashFunc hashFunc);
 
 private:
-    Config& _config;
+    // Factory function for creating a database connection on-demand in background threads
+    //   based on values in _config
+    std::unique_ptr<Database> CreateDbConnection();
 
-    // Maintain a separate database connection for the background thread
-    std::unique_ptr<Database> _database;
+    Config& _config;
     std::unordered_map<HashFunc, std::shared_ptr<Hasher>> _passwordHashers;
 
     struct UpdateState

--- a/src/hashupdater.hpp
+++ b/src/hashupdater.hpp
@@ -22,7 +22,6 @@ class PasswordHashUpdater
 {
 public:
     PasswordHashUpdater(Config &config, const std::unordered_map<HashFunc, std::shared_ptr<Hasher>>& passwordHashers);
-    ~PasswordHashUpdater();
 
     void QueueUpdatePassword(const std::string& username, util::secure_string&& password, HashFunc hashFunc);
 
@@ -31,10 +30,7 @@ private:
 
     // Maintain a separate database connection for the background thread
     std::unique_ptr<Database> _database;
-
     std::unordered_map<HashFunc, std::shared_ptr<Hasher>> _passwordHashers;
-
-    volatile bool _terminating;
 
     struct UpdateState
     {
@@ -42,12 +38,4 @@ private:
         util::secure_string password;
         HashFunc hashFunc;
     };
-
-    std::thread _updateThread;
-    util::Semaphore _updateSem;
-
-    std::mutex _updateQueueLock;
-    std::queue<UpdateState> _updateQueue;
-
-    void updateThreadProc();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,12 +316,14 @@ int eoserv_main(int argc, char *argv[])
 			}
 		}
 
-		if (static_cast<int>(config["ThreadPoolThreads"]) > 0)
+		if (static_cast<int>(config["ThreadPoolThreads"]) <= 0)
 		{
-			size_t threadPoolThreads = static_cast<size_t>(static_cast<int>(config["ThreadPoolThreads"]));
-			Console::Out("Setting number of threadpool threads to %d", threadPoolThreads);
-			util::ThreadPool::SetNumThreads(threadPoolThreads);
+			config["ThreadPoolThreads"] = static_cast<int>(std::thread::hardware_concurrency());
 		}
+
+		size_t threadPoolThreads = static_cast<size_t>(static_cast<int>(config["ThreadPoolThreads"]));
+		Console::Out("Setting number of threadpool threads to %d", threadPoolThreads);
+		util::ThreadPool::SetNumThreads(threadPoolThreads);
 
 		std::array<std::string, 6> dbinfo;
 		dbinfo[0] = std::string(config["DBType"]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,7 +318,13 @@ int eoserv_main(int argc, char *argv[])
 
 		if (static_cast<int>(config["ThreadPoolThreads"]) <= 0)
 		{
+			Console::Wrn("Overriding user-defined threadpool threads with %d", std::thread::hardware_concurrency());
 			config["ThreadPoolThreads"] = static_cast<int>(std::thread::hardware_concurrency());
+		}
+		else if (static_cast<int>(config["ThreadPoolThreads"]) > util::ThreadPool::MAX_THREADS)
+		{
+			Console::Wrn("Overriding user-defined threadpool threads with %d", util::ThreadPool::MAX_THREADS);
+			config["ThreadPoolThreads"] = static_cast<int>(util::ThreadPool::MAX_THREADS);
 		}
 
 		size_t threadPoolThreads = static_cast<size_t>(static_cast<int>(config["ThreadPoolThreads"]));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -321,7 +321,7 @@ int eoserv_main(int argc, char *argv[])
 			Console::Wrn("Overriding user-defined threadpool threads with %d", std::thread::hardware_concurrency());
 			config["ThreadPoolThreads"] = static_cast<int>(std::thread::hardware_concurrency());
 		}
-		else if (static_cast<int>(config["ThreadPoolThreads"]) > util::ThreadPool::MAX_THREADS)
+		else if (static_cast<size_t>(config["ThreadPoolThreads"].GetInt()) > util::ThreadPool::MAX_THREADS)
 		{
 			Console::Wrn("Overriding user-defined threadpool threads with %d", util::ThreadPool::MAX_THREADS);
 			config["ThreadPoolThreads"] = static_cast<int>(util::ThreadPool::MAX_THREADS);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,8 @@
 #include "platform.h"
 #include "version.h"
 
+#include "util/threadpool.hpp"
+
 #ifdef WIN32
 #include "eoserv_windows.h"
 #include "extra/ntservice.hpp"
@@ -312,6 +314,13 @@ int eoserv_main(int argc, char *argv[])
 					Console::Wrn("Failed to change stdout buffer settings");
 				}
 			}
+		}
+
+		if (static_cast<int>(config["ThreadPoolThreads"]) > 0)
+		{
+			size_t threadPoolThreads = static_cast<size_t>(static_cast<int>(config["ThreadPoolThreads"]));
+			Console::Out("Setting number of threadpool threads to %d", threadPoolThreads);
+			util::ThreadPool::SetNumThreads(threadPoolThreads);
 		}
 
 		std::array<std::string, 6> dbinfo;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,8 +33,8 @@
 #include "extra/ntservice.hpp"
 #endif // WIN32
 
-volatile std::sig_atomic_t eoserv_sig_abort = false;
-volatile std::sig_atomic_t eoserv_sig_rehash = false;
+extern volatile std::sig_atomic_t eoserv_sig_abort;
+volatile std::sig_atomic_t eoserv_sig_rehash;
 volatile bool eoserv_running = true;
 
 #ifdef SIGHUP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,12 +318,18 @@ int eoserv_main(int argc, char *argv[])
 
 		if (static_cast<int>(config["ThreadPoolThreads"]) <= 0)
 		{
-			Console::Wrn("Overriding user-defined threadpool threads with %d", std::thread::hardware_concurrency());
-			config["ThreadPoolThreads"] = static_cast<int>(std::thread::hardware_concurrency());
+			if (std::thread::hardware_concurrency() == 0)
+			{
+				config["ThreadPoolThreads"] = static_cast<int>(util::ThreadPool::DEFAULT_THREADS);
+			}
+			else
+			{
+				config["ThreadPoolThreads"] = static_cast<int>(std::thread::hardware_concurrency());
+			}
 		}
 		else if (static_cast<size_t>(config["ThreadPoolThreads"].GetInt()) > util::ThreadPool::MAX_THREADS)
 		{
-			Console::Wrn("Overriding user-defined threadpool threads with %d", util::ThreadPool::MAX_THREADS);
+			Console::Wrn("Value of ThreadPoolThreads is too high. Overriding user-defined threadpool threads with %d", util::ThreadPool::MAX_THREADS);
 			config["ThreadPoolThreads"] = static_cast<int>(util::ThreadPool::MAX_THREADS);
 		}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@
 #endif // WIN32
 
 extern volatile std::sig_atomic_t eoserv_sig_abort;
-volatile std::sig_atomic_t eoserv_sig_rehash;
+volatile std::sig_atomic_t eoserv_sig_rehash = false;
 volatile bool eoserv_running = true;
 
 #ifdef SIGHUP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,7 +316,8 @@ int eoserv_main(int argc, char *argv[])
 			}
 		}
 
-		if (static_cast<int>(config["ThreadPoolThreads"]) <= 0)
+		const auto threadPoolThreads = static_cast<int>(config["ThreadPoolThreads"]);
+		if (threadPoolThreads <= 0)
 		{
 			if (std::thread::hardware_concurrency() == 0)
 			{
@@ -327,15 +328,15 @@ int eoserv_main(int argc, char *argv[])
 				config["ThreadPoolThreads"] = static_cast<int>(std::thread::hardware_concurrency());
 			}
 		}
-		else if (static_cast<size_t>(config["ThreadPoolThreads"].GetInt()) > util::ThreadPool::MAX_THREADS)
+		else if (static_cast<size_t>(threadPoolThreads) > util::ThreadPool::MAX_THREADS)
 		{
-			Console::Wrn("Value of ThreadPoolThreads is too high. Overriding user-defined threadpool threads with %d", util::ThreadPool::MAX_THREADS);
+			Console::Wrn("Value of ThreadPoolThreads is too high. Overriding user-defined threadpool threads (%d) with %d", threadPoolThreads, util::ThreadPool::MAX_THREADS);
 			config["ThreadPoolThreads"] = static_cast<int>(util::ThreadPool::MAX_THREADS);
 		}
 
-		size_t threadPoolThreads = static_cast<size_t>(static_cast<int>(config["ThreadPoolThreads"]));
-		Console::Out("Setting number of threadpool threads to %d", threadPoolThreads);
-		util::ThreadPool::SetNumThreads(threadPoolThreads);
+		const auto threadPoolSize = static_cast<size_t>(static_cast<int>(config["ThreadPoolThreads"]));
+		Console::Out("Setting number of threadpool threads to %d", threadPoolSize);
+		util::ThreadPool::SetNumThreads(threadPoolSize);
 
 		std::array<std::string, 6> dbinfo;
 		dbinfo[0] = std::string(config["DBType"]);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2128,7 +2128,6 @@ void Map::SpellGroup(Character *from, unsigned short spell_id)
 		if (member->map != from->map)
 			continue;
 
-		int displayhp = spell.hp;
 		int hpgain = spell.hp;
 
 		if (this->world->config["LimitDamage"])

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -388,6 +388,8 @@ Quest_Context::Quest_Context(Character* character, const Quest* quest)
 
 void Quest_Context::BeginState(const std::string& name, const EOPlus::State& state)
 {
+	(void)name;
+
 	this->state_desc = state.desc;
 
 	for (auto it = this->progress.begin(); it != this->progress.end(); )

--- a/src/test/util/semaphore_test.cpp
+++ b/src/test/util/semaphore_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <thread>
 
 #include "util/semaphore.hpp"
 

--- a/src/test/util/semaphore_test.cpp
+++ b/src/test/util/semaphore_test.cpp
@@ -1,0 +1,130 @@
+#include <gtest/gtest.h>
+
+#include "util/semaphore.hpp"
+
+using Semaphore = util::Semaphore;
+
+GTEST_TEST(SemaphoreTests, WaitDecrementsCount)
+{
+    const size_t count = 5;
+    Semaphore s(count, count);
+
+    s.Wait();
+
+    ASSERT_EQ(count-1, s.Count());
+}
+
+GTEST_TEST(SemaphoreTests, ReleaseIncrementsCount)
+{
+    const size_t count = 0;
+    const size_t maxCount = 5;
+    Semaphore s(count, maxCount);
+
+    s.Release();
+
+    ASSERT_EQ(count+1, s.Count());
+}
+
+GTEST_TEST(SemaphoreTests, ReleaseDoesNotGoBeyondMaxCount)
+{
+    const size_t count = 5;
+    Semaphore s(count, count);
+
+    s.Release();
+
+    ASSERT_EQ(count, s.Count());
+}
+
+GTEST_TEST(SemaphoreTests, WaitFailsIfTimeoutExpires)
+{
+    const size_t count = 0;
+    const size_t maxCount = 5;
+    Semaphore s(count, maxCount);
+
+    auto result = s.Wait(std::chrono::milliseconds(50));
+
+    ASSERT_FALSE(result);
+}
+
+GTEST_TEST(SemaphoreTests, WaitReleasesWhenSignalled)
+{
+    const size_t count = 0;
+    const size_t maxCount = 5;
+    Semaphore s(count, maxCount);
+
+    std::thread signaller([&s]()
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        s.Release();
+    });
+
+    auto result = s.Wait(std::chrono::milliseconds(1000));
+
+    ASSERT_TRUE(result);
+    ASSERT_EQ(count, s.Count());
+
+    signaller.join();
+}
+
+GTEST_TEST(SemaphoreTests, MultipleWaitsReleaseWhenSignalled)
+{
+    const size_t count = 0;
+    const size_t maxCount = 5;
+    Semaphore s(count, maxCount);
+
+    volatile bool res1 = false, res2 = false;
+
+    std::thread waiter_1([&s, &res1]()
+    {
+        res1 = s.Wait(std::chrono::seconds(1));
+    });
+
+    std::thread waiter_2([&s, &res2]()
+    {
+        res2 = s.Wait(std::chrono::seconds(1));
+    });
+
+    s.Release(2);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    ASSERT_TRUE(res1);
+    ASSERT_TRUE(res2);
+
+    ASSERT_EQ(count, s.Count());
+
+    waiter_1.join();
+    waiter_2.join();
+}
+
+GTEST_TEST(SemaphoreTests, ResetSignalsAllWaiters)
+{
+    const size_t count = 0;
+    const size_t maxCount = 5;
+    Semaphore s(count, maxCount);
+
+    volatile bool res1 = false, res2 = false;
+
+    std::thread waiter_1([&s, &res1]()
+    {
+        res1 = s.Wait(std::chrono::seconds(1));
+    });
+
+    std::thread waiter_2([&s, &res2]()
+    {
+        res2 = s.Wait(std::chrono::seconds(1));
+    });
+
+    s.Reset(maxCount, maxCount*2);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    ASSERT_TRUE(res1);
+    ASSERT_TRUE(res2);
+
+    // The waiters will take some of the count released by the call to Reset
+    ASSERT_EQ(maxCount - 2, s.Count());
+    ASSERT_EQ(maxCount*2, s.MaxCount());
+
+    waiter_1.join();
+    waiter_2.join();
+}

--- a/src/test/util/threadpool_test.cpp
+++ b/src/test/util/threadpool_test.cpp
@@ -1,0 +1,186 @@
+#include <gtest/gtest.h>
+
+#include "util/semaphore.hpp"
+#include "util/threadpool.hpp"
+
+using Semaphore = util::Semaphore;
+using ThreadPool = util::ThreadPool;
+
+#define SLEEP_MS(x) std::this_thread::sleep_for(std::chrono::milliseconds(x))
+
+// Testing class that allows the thread pool to be instanced
+// Prevents cross-test access from causing exceptions/hangs
+class TestThreadPool : public ThreadPool
+{
+public:
+    TestThreadPool(size_t numThreads = 4)
+        : ThreadPool(numThreads) { }
+
+    void QueueWork(const util::ThreadPool::WorkFunc workFunc, const void * state)
+    {
+        this->queueInternal(workFunc, state);
+    }
+
+    void SetNumThreads(size_t numThreads)
+    {
+        this->setNumThreadsInternal(numThreads);
+    }
+
+    // Allow for tests to force threadpool threads to join so tests don't hang
+    void JoinAll()
+    {
+        this->_terminating = true;
+        this->_workReadySemaphore.Release(this->_threads.size());
+
+        for (auto& thread : this->_threads)
+        {
+            thread.join();
+        }
+
+        this->_threads.clear();
+    }
+};
+
+GTEST_TEST(ThreadPoolTests, QueueDoesWork)
+{
+    volatile bool done = false;
+    auto workFunc = [&done](const void * state)
+    {
+        SLEEP_MS(100);
+        done = true;
+    };
+
+    ThreadPool::Queue(workFunc, nullptr);
+    SLEEP_MS(200);
+
+    ASSERT_TRUE(done);
+}
+
+GTEST_TEST(ThreadPoolTests, QueueManyDoesAllWork)
+{
+    const size_t numThreads = 10;
+
+    std::vector<bool> results;
+    results.resize(numThreads, false);
+
+    ASSERT_EQ(numThreads, results.size());
+
+    auto workFunc = [&results](const void * state)
+    {
+        auto ndx = reinterpret_cast<const size_t*>(state);
+        SLEEP_MS(50);
+        results[*ndx] = true;
+        delete ndx;
+    };
+
+    for (size_t i = 0; i < numThreads; ++i)
+        ThreadPool::Queue(workFunc, new size_t(i));
+
+    SLEEP_MS(500);
+
+    for (size_t i = 0; i < numThreads; ++i)
+    {
+        ASSERT_TRUE(results[i]) << "Expected work to be completed, but was not (result " << i << ")";
+    }
+}
+
+GTEST_TEST(ThreadPoolTests, QueueRespectsMaxThreads)
+{
+    const size_t defaultMaxThreads = 4;
+
+    TestThreadPool testThreadPool(defaultMaxThreads);
+
+    Semaphore s(0, defaultMaxThreads);
+    volatile unsigned workCounter = 0;
+
+    auto workFunc = [&workCounter, &s](const void * state)
+    {
+        workCounter++;
+        s.Wait(std::chrono::milliseconds(1000));
+    };
+
+    for (size_t i = 0; i < defaultMaxThreads + 1; i++)
+    {
+        testThreadPool.QueueWork(workFunc, nullptr);
+    }
+
+    SLEEP_MS(200);
+    ASSERT_EQ(workCounter, defaultMaxThreads) << "Expected work counter to match the maximum number of threads";
+
+    // Release should allow one of the queued workers to complete
+    s.Release();
+
+    SLEEP_MS(100);
+    ASSERT_EQ(workCounter, defaultMaxThreads+1) << "Expected work counter to increase when allowing another thread to work";
+
+    s.Release(defaultMaxThreads);
+    testThreadPool.JoinAll();
+}
+
+GTEST_TEST(ThreadPoolTests, ResizeLessThreadsReducesThreadPoolSize)
+{
+    const size_t defaultMaxThreads = 4;
+    const size_t newThreadPoolSize = 1;
+
+    TestThreadPool testThreadPool(defaultMaxThreads);
+    testThreadPool.SetNumThreads(newThreadPoolSize);
+
+    Semaphore s(0);
+    volatile unsigned workCounter = 0;
+
+    auto workFunc = [&workCounter, &s](const void * state)
+    {
+        workCounter++;
+        s.Wait(std::chrono::milliseconds(1000));
+    };
+
+    for (size_t i = 0; i < defaultMaxThreads + 1; i++)
+    {
+        testThreadPool.QueueWork(workFunc, nullptr);
+    }
+
+    SLEEP_MS(100);
+    ASSERT_EQ(workCounter, newThreadPoolSize) << "Expected work counter to match decreased threadpool size";
+
+    // Release should allow one of the queued workers to complete
+    s.Release();
+
+    SLEEP_MS(100);
+    ASSERT_EQ(workCounter, newThreadPoolSize+1) << "Expected work counter to increment by one";
+
+    s.Release(defaultMaxThreads);
+
+    SLEEP_MS(100);
+    ASSERT_EQ(workCounter, defaultMaxThreads+1) << "Expected work counter to match number of queued work procs";
+    testThreadPool.JoinAll();
+}
+
+GTEST_TEST(ThreadPoolTests, ResizeMoreThreadsIncreasesThreadPoolSize)
+{
+    const size_t defaultMaxThreads = 4;
+    const size_t newThreadPoolSize = 8;
+
+    TestThreadPool testThreadPool(defaultMaxThreads);
+    testThreadPool.SetNumThreads(newThreadPoolSize);
+
+    Semaphore s(0);
+    volatile unsigned workCounter = 0;
+
+    auto workFunc = [&workCounter, &s](const void * state)
+    {
+        workCounter++;
+        s.Wait(std::chrono::milliseconds(1000));
+    };
+
+    for (size_t i = 0; i < newThreadPoolSize; i++)
+    {
+        testThreadPool.QueueWork(workFunc, nullptr);
+    }
+
+    SLEEP_MS(100);
+    ASSERT_EQ(workCounter, newThreadPoolSize) << "Expected work counter to match increased threadpool size";
+
+    s.Release(newThreadPoolSize);
+
+    testThreadPool.JoinAll();
+}

--- a/src/test/util/threadpool_test.cpp
+++ b/src/test/util/threadpool_test.cpp
@@ -46,6 +46,7 @@ GTEST_TEST(ThreadPoolTests, QueueDoesWork)
     volatile bool done = false;
     auto workFunc = [&done](const void * state)
     {
+        (void)state;
         SLEEP_MS(100);
         done = true;
     };
@@ -95,6 +96,7 @@ GTEST_TEST(ThreadPoolTests, QueueRespectsMaxThreads)
 
     auto workFunc = [&workCounter, &s](const void * state)
     {
+        (void)state;
         workCounter++;
         s.Wait(std::chrono::milliseconds(1000));
     };
@@ -130,6 +132,7 @@ GTEST_TEST(ThreadPoolTests, ResizeLessThreadsReducesThreadPoolSize)
 
     auto workFunc = [&workCounter, &s](const void * state)
     {
+        (void)state;
         workCounter++;
         s.Wait(std::chrono::milliseconds(1000));
     };
@@ -168,6 +171,7 @@ GTEST_TEST(ThreadPoolTests, ResizeMoreThreadsIncreasesThreadPoolSize)
 
     auto workFunc = [&workCounter, &s](const void * state)
     {
+        (void)state;
         workCounter++;
         s.Wait(std::chrono::milliseconds(1000));
     };

--- a/src/test/util/threadpool_test.cpp
+++ b/src/test/util/threadpool_test.cpp
@@ -21,6 +21,8 @@ public:
         this->queueInternal(workFunc, state);
     }
 
+    size_t GetNumThreads() const { return this->_threads.size(); }
+
     void SetNumThreads(size_t numThreads)
     {
         this->setNumThreadsInternal(numThreads);
@@ -40,6 +42,25 @@ public:
         this->_threads.clear();
     }
 };
+
+GTEST_TEST(ThreadPoolTests, ZeroThreadsUsesDefault)
+{
+    TestThreadPool t(0);
+    ASSERT_EQ(ThreadPool::DEFAULT_THREADS, t.GetNumThreads());
+}
+
+GTEST_TEST(ThreadPoolTests, GreaterThanMaxThreadsUsesDefault)
+{
+    {
+        TestThreadPool t(ThreadPool::MAX_THREADS);
+        ASSERT_EQ(ThreadPool::MAX_THREADS, t.GetNumThreads());
+    }
+
+    {
+        TestThreadPool t(ThreadPool::MAX_THREADS + 1);
+        ASSERT_EQ(ThreadPool::DEFAULT_THREADS, t.GetNumThreads());
+    }
+}
 
 GTEST_TEST(ThreadPoolTests, QueueDoesWork)
 {
@@ -117,6 +138,28 @@ GTEST_TEST(ThreadPoolTests, QueueRespectsMaxThreads)
 
     s.Release(defaultMaxThreads);
     testThreadPool.JoinAll();
+}
+
+GTEST_TEST(ThreadPoolTests, ResizeToZeroUsesDefault)
+{
+    TestThreadPool t;
+    t.SetNumThreads(0);
+    ASSERT_EQ(ThreadPool::DEFAULT_THREADS, t.GetNumThreads());
+}
+
+GTEST_TEST(ThreadPoolTests, ResizeToGreaterThanMaxUsesDefault)
+{
+    {
+        TestThreadPool t;
+        t.SetNumThreads(ThreadPool::MAX_THREADS);
+        ASSERT_EQ(ThreadPool::MAX_THREADS, t.GetNumThreads());
+    }
+
+    {
+        TestThreadPool t;
+        t.SetNumThreads(ThreadPool::MAX_THREADS+1);
+        ASSERT_EQ(ThreadPool::DEFAULT_THREADS, t.GetNumThreads());
+    }
 }
 
 GTEST_TEST(ThreadPoolTests, ResizeLessThreadsReducesThreadPoolSize)

--- a/src/test/util/threadpool_test.cpp
+++ b/src/test/util/threadpool_test.cpp
@@ -23,22 +23,22 @@ public:
 
     size_t GetNumThreads() const { return this->_threads.size(); }
 
+    bool IsShutdown() const { return this->_workReadySemaphore.Count() == this->_threads.size() && this->_terminating; }
+
     void SetNumThreads(size_t numThreads)
     {
         this->setNumThreadsInternal(numThreads);
     }
 
+    void Shutdown()
+    {
+        this->shutdownInternal();
+    }
+
     // Allow for tests to force threadpool threads to join so tests don't hang
     void JoinAll()
     {
-        this->_terminating = true;
-        this->_workReadySemaphore.Release(this->_threads.size());
-
-        for (auto& thread : this->_threads)
-        {
-            thread.join();
-        }
-
+        this->Shutdown();
         this->_threads.clear();
     }
 };
@@ -228,6 +228,56 @@ GTEST_TEST(ThreadPoolTests, ResizeMoreThreadsIncreasesThreadPoolSize)
     ASSERT_EQ(workCounter, newThreadPoolSize) << "Expected work counter to match increased threadpool size";
 
     s.Release(newThreadPoolSize);
+
+    testThreadPool.JoinAll();
+}
+
+GTEST_TEST(ThreadPoolTests, ShutdownAllowsWorkToComplete)
+{
+    const size_t defaultMaxThreads = 1;
+
+    TestThreadPool testThreadPool(defaultMaxThreads);
+
+    volatile unsigned workCounter = 0;
+
+    auto workFunc = [&workCounter](const void * state)
+    {
+        (void)state;
+        SLEEP_MS(1000);
+        workCounter++;
+    };
+
+    testThreadPool.QueueWork(workFunc, nullptr);
+    SLEEP_MS(100);
+
+    testThreadPool.Shutdown();
+    ASSERT_TRUE(testThreadPool.IsShutdown()) << "Expected threadpool to be shutdown but it was not";
+    ASSERT_EQ(workCounter, 1) << "Expected work counter to indicate threadpool task had completed";
+
+    testThreadPool.JoinAll();
+}
+
+GTEST_TEST(ThreadPoolTests, ShutdownPreventsStateChanges)
+{
+    const size_t defaultMaxThreads = 1;
+
+    TestThreadPool testThreadPool(defaultMaxThreads);
+
+    volatile unsigned workCounter = 0;
+
+    auto workFunc = [&workCounter](const void * state)
+    {
+        (void)state;
+        SLEEP_MS(1000);
+        workCounter++;
+    };
+
+    testThreadPool.QueueWork(workFunc, nullptr);
+    testThreadPool.Shutdown();
+
+    ASSERT_THROW(testThreadPool.QueueWork([](const void * state) { }, nullptr), std::runtime_error) << "Expected exception when queuing ThreadPool work during shutdown";
+    ASSERT_THROW(testThreadPool.SetNumThreads(defaultMaxThreads + 1), std::runtime_error) << "Expected exception when resizing ThreadPool during shutdown";
+    ASSERT_NO_THROW(testThreadPool.SetNumThreads(defaultMaxThreads)) << "Expected no exception when setting same number of threads during shutdown";
 
     testThreadPool.JoinAll();
 }

--- a/src/util/semaphore.cpp
+++ b/src/util/semaphore.cpp
@@ -16,20 +16,6 @@ void Semaphore::Wait()
     --this->_count;
 }
 
-template <class _Rep, class _Period>
-bool Semaphore::Wait(std::chrono::duration<_Rep, _Period> timeout)
-{
-    std::unique_lock<std::mutex> lock(this->_mut);
-    if (!this->_event.wait_for(lock, timeout, [&]() { return _count > 0; }))
-    {
-        return false;
-    }
-
-    --this->_count;
-
-    return true;
-}
-
 void Semaphore::Release(size_t count)
 {
     std::unique_lock<std::mutex> lock(this->_mut);

--- a/src/util/semaphore.cpp
+++ b/src/util/semaphore.cpp
@@ -34,11 +34,13 @@ void Semaphore::Release(size_t count)
 {
     std::unique_lock<std::mutex> lock(this->_mut);
 
+    auto oldCount = this->_count;
     this->_count = this->_count + count >= this->_maxCount
         ? this->_maxCount
         : this->_count + count;
 
-    this->_event.notify_one();
+    for (size_t i = oldCount; i < this->_count; ++i)
+        this->_event.notify_one();
 }
 
 void Semaphore::Reset(size_t count, size_t maxCount)

--- a/src/util/semaphore.cpp
+++ b/src/util/semaphore.cpp
@@ -33,8 +33,22 @@ bool Semaphore::Wait(std::chrono::duration<_Rep, _Period> timeout)
 void Semaphore::Release(size_t count)
 {
     std::unique_lock<std::mutex> lock(this->_mut);
-    this->_count += count;
+
+    this->_count = this->_count + count >= this->_maxCount
+        ? this->_maxCount
+        : this->_count + count;
+
     this->_event.notify_one();
+}
+
+void Semaphore::Reset(size_t count, size_t maxCount)
+{
+    std::unique_lock<std::mutex> lock(this->_mut);
+
+    this->_event.notify_all();
+
+    this->_count = count;
+    this->_maxCount = maxCount;
 }
 
 }

--- a/src/util/semaphore.hpp
+++ b/src/util/semaphore.hpp
@@ -26,6 +26,8 @@ public:
 
     void Release(size_t count = 1);
 
+    size_t Count() const { return this->_count; }
+
 private:
     size_t _count;
     std::condition_variable _event;

--- a/src/util/semaphore.hpp
+++ b/src/util/semaphore.hpp
@@ -39,4 +39,18 @@ private:
     std::mutex _mut;
 };
 
+template <class _Rep, class _Period>
+bool Semaphore::Wait(std::chrono::duration<_Rep, _Period> timeout)
+{
+    std::unique_lock<std::mutex> lock(this->_mut);
+    if (!this->_event.wait_for(lock, timeout, [&]() { return _count > 0; }))
+    {
+        return false;
+    }
+
+    --this->_count;
+
+    return true;
+}
+
 }

--- a/src/util/semaphore.hpp
+++ b/src/util/semaphore.hpp
@@ -14,7 +14,9 @@ namespace util
 class Semaphore
 {
 public:
-    Semaphore(size_t initialCount) : _count(initialCount) { }
+    Semaphore(size_t initialCount, size_t maxCount = static_cast<size_t>(-1))
+        : _count(initialCount)
+        , _maxCount(maxCount) { }
 
     Semaphore(const Semaphore&) = delete;
     Semaphore(Semaphore&& other) = delete;
@@ -25,11 +27,14 @@ public:
     bool Wait(std::chrono::duration<_Rep, _Period> timeout);
 
     void Release(size_t count = 1);
+    void Reset(size_t count, size_t maxCount);
 
     size_t Count() const { return this->_count; }
+    size_t MaxCount() const { return this->_maxCount; }
 
 private:
     size_t _count;
+    size_t _maxCount;
     std::condition_variable _event;
     std::mutex _mut;
 };

--- a/src/util/semaphore.hpp
+++ b/src/util/semaphore.hpp
@@ -27,7 +27,7 @@ public:
     bool Wait(std::chrono::duration<_Rep, _Period> timeout);
 
     void Release(size_t count = 1);
-    void Reset(size_t count, size_t maxCount);
+    void Reset(size_t count, size_t maxCount = static_cast<size_t>(-1));
 
     size_t Count() const { return this->_count; }
     size_t MaxCount() const { return this->_maxCount; }

--- a/src/util/threadpool.cpp
+++ b/src/util/threadpool.cpp
@@ -23,7 +23,7 @@ namespace util
 
     ThreadPool::ThreadPool(size_t numThreads)
         : _terminating(false)
-        , _workReadySemaphore(0, numThreads > MAX_THREADS ? MAX_THREADS : numThreads)
+        , _workReadySemaphore(0)
     {
         for (size_t i = 0; i < numThreads; i++)
         {
@@ -55,12 +55,12 @@ namespace util
 
     void ThreadPool::setNumThreadsInternal(size_t numWorkers)
     {
-        if (numWorkers == this->_workReadySemaphore.MaxCount())
+        if (numWorkers == this->_threads.size())
             return;
 
         std::lock_guard<std::mutex> queueGuard(this->_workQueueLock);
 
-        if (numWorkers < this->_workReadySemaphore.MaxCount())
+        if (numWorkers < this->_threads.size())
         {
             while (!this->_work.empty())
                 this->_work.pop();
@@ -75,7 +75,7 @@ namespace util
             this->_terminating = false;
         }
 
-        this->_workReadySemaphore.Reset(0, numWorkers);
+        this->_workReadySemaphore.Reset(0);
 
         for (size_t i = this->_threads.size(); i < numWorkers; ++i)
         {

--- a/src/util/threadpool.cpp
+++ b/src/util/threadpool.cpp
@@ -49,6 +49,11 @@ namespace util
 
     void ThreadPool::queueInternal(const ThreadPool::WorkFunc workerFunction, const void* state)
     {
+        if (this->_terminating)
+        {
+            throw std::runtime_error("Unable to queue work while ThreadPool is terminating");
+        }
+
         std::lock_guard<std::mutex> queueGuard(this->_workQueueLock);
 
         auto newPair = std::make_pair(workerFunction, state);
@@ -66,6 +71,11 @@ namespace util
 
         if (numWorkers == this->_threads.size())
             return;
+
+        if (this->_terminating)
+        {
+            throw std::runtime_error("Unable to set number of threads while ThreadPool is terminating");
+        }
 
         std::lock_guard<std::mutex> queueGuard(this->_workQueueLock);
 

--- a/src/util/threadpool.cpp
+++ b/src/util/threadpool.cpp
@@ -1,3 +1,9 @@
+
+/* $Id$
+ * EOSERV is released under the zlib license.
+ * See LICENSE.txt for more info.
+ */
+
 #include "threadpool.hpp"
 
 namespace util
@@ -14,15 +20,15 @@ namespace util
         return threadPoolInstance.AvailableWorkers();
     }
 
+    void ThreadPool::SetNumThreads(size_t numThreads)
+    {
+        threadPoolInstance.SetNumWorkers(numThreads);
+    }
+
     ThreadPool::ThreadPool(size_t numThreads)
         : _terminating(false)
-        , _workReadySemaphore(0)
+        , _workReadySemaphore(0, numThreads)
     {
-        if (numThreads == 0)
-        {
-            numThreads = std::thread::hardware_concurrency();
-        }
-
         for (size_t i = 0; i < numThreads; i++)
         {
             auto newThread = std::thread([this]() { this->_worker(); });
@@ -49,6 +55,37 @@ namespace util
         this->_work.emplace(newPair);
 
         this->_workReadySemaphore.Release();
+    }
+
+    void ThreadPool::SetNumWorkers(size_t numWorkers)
+    {
+        if (numWorkers == this->AvailableWorkers())
+            return;
+
+        std::lock_guard<std::mutex> queueGuard(this->_workQueueLock);
+
+        if (numWorkers < this->AvailableWorkers())
+        {
+            while (!this->_work.empty())
+                this->_work.pop();
+
+            this->_terminating = true;
+            this->_workReadySemaphore.Release(this->_threads.size());
+
+            for (auto& thread : this->_threads)
+                thread.join();
+
+            this->_threads.clear();
+            this->_terminating = false;
+
+            this->_workReadySemaphore.Reset(0, numWorkers);
+        }
+
+        for (size_t i = this->_threads.size(); i < numWorkers; ++i)
+        {
+            auto newThread = std::thread([this]() { this->_worker(); });
+            this->_threads.push_back(std::move(newThread));
+        }
     }
 
     void ThreadPool::_worker()

--- a/src/util/threadpool.cpp
+++ b/src/util/threadpool.cpp
@@ -1,0 +1,74 @@
+#include "threadpool.hpp"
+
+namespace util
+{
+    static ThreadPool threadPoolInstance;
+
+    void ThreadPool::Queue(const WorkFunc workerFunction, const void* state)
+    {
+        threadPoolInstance.QueueWork(workerFunction, state);
+    }
+
+    size_t ThreadPool::Workers()
+    {
+        return threadPoolInstance.AvailableWorkers();
+    }
+
+    ThreadPool::ThreadPool(size_t numThreads)
+        : _terminating(false)
+        , _workReadySemaphore(0)
+    {
+        if (numThreads == 0)
+        {
+            numThreads = std::thread::hardware_concurrency();
+        }
+
+        for (size_t i = 0; i < numThreads; i++)
+        {
+            auto newThread = std::thread([this]() { this->_worker(); });
+            this->_threads.push_back(std::move(newThread));
+        }
+    }
+
+    ThreadPool::~ThreadPool()
+    {
+        this->_terminating = true;
+        this->_workReadySemaphore.Release(this->_threads.size());
+
+        for (auto& thread : this->_threads)
+        {
+            thread.join();
+        }
+    }
+
+    void ThreadPool::QueueWork(const ThreadPool::WorkFunc workerFunction, const void* state)
+    {
+        std::lock_guard<std::mutex> queueGuard(this->_workQueueLock);
+
+        auto newPair = std::make_pair(workerFunction, state);
+        this->_work.emplace(newPair);
+
+        this->_workReadySemaphore.Release();
+    }
+
+    void ThreadPool::_worker()
+    {
+        while (!this->_terminating)
+        {
+            this->_workReadySemaphore.Wait();
+
+            if (this->_terminating)
+                break;
+
+            std::unique_ptr<WorkFuncWithState> workPair;
+
+            {
+                std::lock_guard<std::mutex> queueGuard(this->_workQueueLock);
+                workPair = std::make_unique<WorkFuncWithState>(std::move(this->_work.front()));
+                this->_work.pop();
+            }
+
+            workPair->first(workPair->second);
+        }
+    }
+}

--- a/src/util/threadpool.cpp
+++ b/src/util/threadpool.cpp
@@ -25,6 +25,11 @@ namespace util
         : _terminating(false)
         , _workReadySemaphore(0)
     {
+        if (numThreads == 0 || numThreads > MAX_THREADS)
+        {
+            numThreads = DEFAULT_THREADS;
+        }
+
         for (size_t i = 0; i < numThreads; i++)
         {
             auto newThread = std::thread([this]() { this->_workerProc(); });
@@ -55,6 +60,11 @@ namespace util
 
     void ThreadPool::setNumThreadsInternal(size_t numWorkers)
     {
+        if (numWorkers == 0 || numWorkers > MAX_THREADS)
+        {
+            numWorkers = DEFAULT_THREADS;
+        }
+
         if (numWorkers == this->_threads.size())
             return;
 

--- a/src/util/threadpool.cpp
+++ b/src/util/threadpool.cpp
@@ -16,11 +16,6 @@ namespace util
         threadPoolInstance.queueInternal(workerFunction, state);
     }
 
-    size_t ThreadPool::GetAvailableWorkers()
-    {
-        return threadPoolInstance.getAvailableWorkersInternal();
-    }
-
     void ThreadPool::SetNumThreads(size_t numThreads)
     {
         threadPoolInstance.setNumThreadsInternal(numThreads);

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -22,8 +22,10 @@ namespace util
     public:
         typedef std::function<void(const void*)> WorkFunc;
 
+        // Queue work on the thread pool. Memory allocated and passed to 'state' must be freed by the caller.
         static void Queue(const WorkFunc workerFunction, const void * state);
-        static size_t GetAvailableWorkers();
+
+        // Set the number of threads in the thread pool. Any queued work will be removed. In-progress work will be allowed to complete.
         static void SetNumThreads(size_t numThreads);
 
     public:
@@ -38,7 +40,6 @@ namespace util
         typedef std::pair<const WorkFunc, const void*> WorkFuncWithState;
 
         void queueInternal(const WorkFunc workerFunction, const void * state);
-        size_t getAvailableWorkersInternal() const { return this->_workReadySemaphore.Count(); }
         void setNumThreadsInternal(size_t numWorkers);
 
         void _workerProc();

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -22,7 +22,7 @@ namespace util
         typedef void(*WorkFunc)(const void*);
 
         static void Queue(const WorkFunc workerFunction, const void* state);
-        static size_t Workers();
+        static size_t GetAvailableWorkers();
         static void SetNumThreads(size_t numThreads);
 
     public:
@@ -34,11 +34,11 @@ namespace util
     private:
         typedef std::pair<const WorkFunc, const void*> WorkFuncWithState;
 
-        void QueueWork(const WorkFunc workerFunction, const void* state);
-        size_t AvailableWorkers() const { return this->_workReadySemaphore.Count(); }
-        void SetNumWorkers(size_t numWorkers);
+        void queueInternal(const WorkFunc workerFunction, const void* state);
+        size_t getAvailableWorkersInternal() const { return this->_workReadySemaphore.Count(); }
+        void setNumThreadsInternal(size_t numWorkers);
 
-        void _worker();
+        void _workerProc();
 
         volatile bool _terminating;
 

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -1,0 +1,49 @@
+
+/* $Id$
+ * EOSERV is released under the zlib license.
+ * See LICENSE.txt for more info.
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <memory>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include "semaphore.hpp"
+
+namespace util
+{
+    class ThreadPool
+    {
+    public:
+        typedef void(*WorkFunc)(const void*);
+
+        static void Queue(const WorkFunc workerFunction, const void* state);
+        static size_t Workers();
+
+    public:
+        ThreadPool(size_t numThreads = 0);
+        ThreadPool(const ThreadPool&) = delete;
+        ThreadPool(ThreadPool&&) = delete;
+        virtual ~ThreadPool();
+
+    private:
+        typedef std::pair<const WorkFunc, const void*> WorkFuncWithState;
+
+        void QueueWork(const WorkFunc workerFunction, const void* state);
+        size_t AvailableWorkers() const { return this->_workReadySemaphore.Count(); }
+
+        void _worker();
+
+        volatile bool _terminating;
+
+        Semaphore _workReadySemaphore;
+        std::mutex _workQueueLock;
+        std::queue<WorkFuncWithState> _work;
+
+        std::vector<std::thread> _threads;
+    };
+}

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -37,11 +37,11 @@ namespace util
         static constexpr size_t MAX_THREADS = 32;
     private:
         typedef std::pair<const WorkFunc, const void*> WorkFuncWithState;
+        void _workerProc();
 
+    protected:
         void queueInternal(const WorkFunc workerFunction, const void * state);
         void setNumThreadsInternal(size_t numWorkers);
-
-        void _workerProc();
 
         volatile bool _terminating;
 

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <queue>
 #include <thread>
@@ -19,22 +20,24 @@ namespace util
     class ThreadPool
     {
     public:
-        typedef void(*WorkFunc)(const void*);
+        typedef std::function<void(const void*)> WorkFunc;
 
-        static void Queue(const WorkFunc workerFunction, const void* state);
+        static void Queue(const WorkFunc workerFunction, const void * state);
         static size_t GetAvailableWorkers();
         static void SetNumThreads(size_t numThreads);
 
     public:
-        ThreadPool(size_t numThreads = std::thread::hardware_concurrency());
+        ThreadPool(size_t numThreads = 4);
         ThreadPool(const ThreadPool&) = delete;
         ThreadPool(ThreadPool&&) = delete;
         virtual ~ThreadPool();
 
     private:
+        static constexpr size_t MAX_THREADS = 32;
+
         typedef std::pair<const WorkFunc, const void*> WorkFuncWithState;
 
-        void queueInternal(const WorkFunc workerFunction, const void* state);
+        void queueInternal(const WorkFunc workerFunction, const void * state);
         size_t getAvailableWorkersInternal() const { return this->_workReadySemaphore.Count(); }
         void setNumThreadsInternal(size_t numWorkers);
 

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -34,9 +34,8 @@ namespace util
         ThreadPool(ThreadPool&&) = delete;
         virtual ~ThreadPool();
 
-    private:
         static constexpr size_t MAX_THREADS = 32;
-
+    private:
         typedef std::pair<const WorkFunc, const void*> WorkFuncWithState;
 
         void queueInternal(const WorkFunc workerFunction, const void * state);

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -29,12 +29,14 @@ namespace util
         static void SetNumThreads(size_t numThreads);
 
     public:
-        ThreadPool(size_t numThreads = 4);
+        ThreadPool(size_t numThreads = DEFAULT_THREADS);
         ThreadPool(const ThreadPool&) = delete;
         ThreadPool(ThreadPool&&) = delete;
         virtual ~ThreadPool();
 
         static constexpr size_t MAX_THREADS = 32;
+        static constexpr size_t DEFAULT_THREADS = 4;
+
     private:
         typedef std::pair<const WorkFunc, const void*> WorkFuncWithState;
         void _workerProc();

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -23,9 +23,10 @@ namespace util
 
         static void Queue(const WorkFunc workerFunction, const void* state);
         static size_t Workers();
+        static void SetNumThreads(size_t numThreads);
 
     public:
-        ThreadPool(size_t numThreads = 0);
+        ThreadPool(size_t numThreads = std::thread::hardware_concurrency());
         ThreadPool(const ThreadPool&) = delete;
         ThreadPool(ThreadPool&&) = delete;
         virtual ~ThreadPool();
@@ -35,6 +36,7 @@ namespace util
 
         void QueueWork(const WorkFunc workerFunction, const void* state);
         size_t AvailableWorkers() const { return this->_workReadySemaphore.Count(); }
+        void SetNumWorkers(size_t numWorkers);
 
         void _worker();
 

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -28,6 +28,9 @@ namespace util
         // Set the number of threads in the thread pool. Any queued work will be removed. In-progress work will be allowed to complete.
         static void SetNumThreads(size_t numThreads);
 
+        // Shut down the threadpool
+        static void Shutdown();
+
     public:
         ThreadPool(size_t numThreads = DEFAULT_THREADS);
         ThreadPool(const ThreadPool&) = delete;
@@ -44,6 +47,7 @@ namespace util
     protected:
         void queueInternal(const WorkFunc workerFunction, const void * state);
         void setNumThreadsInternal(size_t numWorkers);
+        void shutdownInternal();
 
         volatile bool _terminating;
 

--- a/tu/system.cpp
+++ b/tu/system.cpp
@@ -16,6 +16,7 @@
 #include "../src/util.cpp"
 #include "../src/util/rpn.cpp"
 #include "../src/util/semaphore.cpp"
+#include "../src/util/threadpool.cpp"
 #include "../src/util/variant.cpp"
 
 #ifdef WIN32

--- a/tu/system.cpp
+++ b/tu/system.cpp
@@ -19,7 +19,3 @@
 #include "../src/util/threadpool.cpp"
 #include "../src/util/variant.cpp"
 
-#ifdef WIN32
-#include "../src/extra/ntservice.cpp"
-#endif // WIN32
-


### PR DESCRIPTION
Threadpool replaces the previous implementation of PaswordHashUpdater and encapsulates the background thread/signaling functionality that queued incoming password version updates. Now, the work is queued on the Threadpool and most of the logic from PasswordHashUpdater is handled by the Threadpool.

Number of threads in the pool defaults to number of CPUs on the system. This can be overridden by a config value but shall not exceed 32 (arbitrarily chosen).

Additionally a bug in semaphore was fixed that did not release the proper number of claims. Semaphore also now has a maximum count that is honored when releasing.